### PR TITLE
Feature - Client factory

### DIFF
--- a/src/lib/Mailtrap.Tests/MailtrapClientFactoryTests.cs
+++ b/src/lib/Mailtrap.Tests/MailtrapClientFactoryTests.cs
@@ -1,0 +1,175 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="MailtrapClientFactoryTests.cs" company="Railsware Products Studio, LLC">
+// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+
+namespace Mailtrap.Tests;
+
+
+[TestFixture]
+internal sealed class MailtrapClientFactoryTests
+{
+    [Test]
+    public void Constructor_OptionsAndDelegate_ShouldThrowArgumentNullException_WhenConfigurationIsNull()
+    {
+        MailtrapClientOptions? options = null;
+
+        var act = () => new MailtrapClientFactory(options!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void Constructor_OptionsAndDelegate_ShouldCallDelegate()
+    {
+        var options = new MailtrapClientOptions("token");
+        var configure = new Mock<Action<IHttpClientBuilder>>();
+
+        using var factory = new MailtrapClientFactory(options, configure.Object);
+
+        configure.Verify(c => c.Invoke(It.IsAny<IHttpClientBuilder>()));
+    }
+
+
+    [Test]
+    public void Constructor_OptionsAndClient_ShouldThrowArgumentNullException_WhenConfigurationIsNull()
+    {
+        MailtrapClientOptions? options = null;
+        var httpClient = Mock.Of<HttpClient>();
+
+        var act = () => new MailtrapClientFactory(options!, httpClient);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void Constructor_OptionsAndClient_ShouldThrowArgumentNullException_WhenHttpClientIsNull()
+    {
+        HttpClient? httpClient = null;
+
+        var act = () => new MailtrapClientFactory(MailtrapClientOptions.Default, httpClient!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Constructor_OptionsAndClient_ShouldUseClientProvided()
+    {
+        var config = new MailtrapClientOptions("token");
+
+        var httpMethod = HttpMethod.Post;
+        var sendUrl = config.SendEndpoint.BaseUrl.Append(UrlSegments.ApiRootSegment, UrlSegments.SendEmailSegment);
+        var messageId = new MessageId("1");
+        var response = new SendEmailResponse(true, [messageId]);
+        using var responseContent = JsonContent.Create(response);
+
+        using var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .Expect(httpMethod, sendUrl.AbsoluteUri)
+            .Respond(HttpStatusCode.OK, responseContent);
+
+        using var factory = new MailtrapClientFactory(config, mockHttp.ToHttpClient());
+
+        var client = factory.CreateClient();
+
+        var request = SendEmailRequest
+            .Create()
+            .From("john.doe@demomailtrap.com", "John Doe")
+            .To("hero.bill@galaxy.net")
+            .Subject("Invitation to Earth")
+            .Text("Dear Bill,\nIt will be a great pleasure to see you on our blue planet next weekend.\nBest regards, John.");
+
+        var _ = await client.SendEmail(request).ConfigureAwait(false);
+
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+
+    [Test]
+    public void Constructor_KeyAndDelegate_ShouldThrowArgumentNullException_WhenApiKeyIsNull()
+    {
+        string? apiKey = null;
+
+        var act = () => new MailtrapClientFactory(apiKey!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void Constructor_KeyAndDelegate_ShouldCallDelegate()
+    {
+        var configure = new Mock<Action<IHttpClientBuilder>>();
+
+        using var client = new MailtrapClientFactory("token", configure.Object);
+
+        configure.Verify(c => c.Invoke(It.IsAny<IHttpClientBuilder>()));
+    }
+
+
+    [Test]
+    public void Constructor_KeyAndClient_ShouldThrowArgumentNullException_WhenApiKeyIsNull()
+    {
+        string? apiKey = null;
+        var httpClient = Mock.Of<HttpClient>();
+
+        var act = () => new MailtrapClientFactory(apiKey!, httpClient);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void Constructor_KeyAndClient_ShouldThrowArgumentNullException_WhenHttpClientIsNull()
+    {
+        HttpClient? httpClient = null;
+
+        var act = () => new MailtrapClientFactory("token", httpClient!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Constructor_KeyAndClient_ShouldUseClientProvided()
+    {
+        var httpMethod = HttpMethod.Post;
+        var sendUrl = MailtrapClientOptions.Default.SendEndpoint.BaseUrl
+            .Append(UrlSegments.ApiRootSegment, UrlSegments.SendEmailSegment);
+        var messageId = new MessageId("1");
+        var response = new SendEmailResponse(true, [messageId]);
+        using var responseContent = JsonContent.Create(response);
+
+        using var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .Expect(httpMethod, sendUrl.AbsoluteUri)
+            .Respond(HttpStatusCode.OK, responseContent);
+
+        using var factory = new MailtrapClientFactory("token", mockHttp.ToHttpClient());
+
+        var client = factory.CreateClient();
+
+        var request = SendEmailRequest
+            .Create()
+            .From("john.doe@demomailtrap.com", "John Doe")
+            .To("hero.bill@galaxy.net")
+            .Subject("Invitation to Earth")
+            .Text("Dear Bill,\nIt will be a great pleasure to see you on our blue planet next weekend.\nBest regards, John.");
+
+        var _ = await client.SendEmail(request).ConfigureAwait(false);
+
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+
+    [Test]
+    public void Dispose_ShouldDisposeInternals()
+    {
+        var factory = new MailtrapClientFactory("token");
+
+        factory.Dispose();
+
+        var act = factory.CreateClient;
+
+        act.Should().Throw<ObjectDisposedException>();
+    }
+}

--- a/src/lib/Mailtrap/GlobalUsings.cs
+++ b/src/lib/Mailtrap/GlobalUsings.cs
@@ -19,6 +19,7 @@ global using FluentValidation.Results;
 
 global using Mailtrap.Constants;
 global using Mailtrap.Extensions;
+global using Mailtrap.Extensions.DependencyInjection;
 global using Mailtrap.Configuration;
 global using Mailtrap.Configuration.Extensions;
 global using Mailtrap.Configuration.Models;

--- a/src/lib/Mailtrap/MailtrapClientFactory.cs
+++ b/src/lib/Mailtrap/MailtrapClientFactory.cs
@@ -1,0 +1,186 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="MailtrapClientFactory.cs" company="Railsware Products Studio, LLC">
+// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+
+namespace Mailtrap;
+
+
+/// <summary>
+/// Default <see cref="IMailtrapClientFactory"/> implementation.
+/// </summary>
+/// 
+/// <remarks>
+/// <para>
+/// Uses <see cref="IHttpClientFactory"/> under the hood to create <see cref="HttpClient"/> instances
+/// and inject them into the <see cref="IMailtrapClient"/> default implementation instances
+/// produced by the factory. Thus, it is recommended to use it as singleton.
+/// </para>
+///
+/// <para>
+/// <see cref="IMailtrapClient"/> default implementation instances, produced by the factory, can be used in any manner,
+/// since they are designed to use unit-of-work pattern under the hood, ensuring proper disposal of resources,
+/// as soon as any operation is completed.
+/// </para>
+/// </remarks>
+
+public sealed class MailtrapClientFactory : IMailtrapClientFactory
+{
+    private readonly ServiceProvider _serviceProvider;
+
+    #region Constructors
+
+    /// <summary>
+    /// Constructor to create a new instance of <see cref="MailtrapClientFactory"/> 
+    /// with provided <paramref name="configuration"/>
+    /// and optional <see cref="HttpClient"/> configuration delegate.
+    /// </summary>
+    /// 
+    /// <param name="configuration">
+    /// <see cref="MailtrapClientOptions"/> instance to configure factory.
+    /// </param>
+    /// 
+    /// <param name="configure">
+    /// Optional delegate to configure underlying <see cref="HttpClient"/>.
+    /// </param>
+    /// 
+    /// <exception cref="ArgumentNullException">
+    /// When <paramref name="configuration"/> is <see langword="null"/>.
+    /// </exception>
+    public MailtrapClientFactory(
+        MailtrapClientOptions configuration,
+        Action<IHttpClientBuilder>? configure = default)
+    {
+        Ensure.NotNull(configuration, nameof(configuration));
+
+        var serviceCollection = new ServiceCollection();
+
+        var httpClientBuilder = serviceCollection.AddMailtrapClient(configuration);
+
+        configure?.Invoke(httpClientBuilder);
+
+        _serviceProvider = serviceCollection.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Constructor to create a new instance of <see cref="MailtrapClientFactory"/> 
+    /// using provided <paramref name="configuration"/>
+    /// and preconfigured external <see cref="HttpClient"/> instance.
+    /// </summary>
+    /// 
+    /// <param name="configuration">
+    /// <see cref="MailtrapClientOptions"/> instance to configure factory.
+    /// </param>
+    /// 
+    /// <param name="httpClient">
+    /// External <see cref="HttpClient"/> instance to use within factory.
+    /// </param>
+    /// 
+    /// <exception cref="ArgumentNullException">
+    /// When <paramref name="configuration"/> or <paramref name="httpClient"/> is <see langword="null"/>.
+    /// </exception>
+    /// 
+    /// <remarks>
+    /// Factory won't dispose captured <paramref name="httpClient"/> instance upon disposal,
+    /// so it is responsibility of the caller to manage its lifecycle properly.
+    /// </remarks>
+    public MailtrapClientFactory(
+        MailtrapClientOptions configuration,
+        HttpClient httpClient)
+    {
+        Ensure.NotNull(configuration, nameof(configuration));
+        Ensure.NotNull(httpClient, nameof(httpClient));
+
+        var serviceCollection = new ServiceCollection();
+
+        serviceCollection.Configure<MailtrapClientOptions>(options => options.Init(configuration));
+
+        serviceCollection.AddMailtrapServices();
+
+        serviceCollection.AddSingleton(httpClient);
+
+        _serviceProvider = serviceCollection.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Shortcut constructor to create a new instance of <see cref="MailtrapClientFactory"/> 
+    /// using provided <paramref name="apiToken"/>
+    /// and optional <see cref="HttpClient"/> configuration delegate.
+    /// <para>
+    /// All other configuration settings will be set to default values.
+    /// </para>
+    /// </summary>
+    /// 
+    /// <param name="apiToken">
+    /// API authentication token.
+    /// </param>
+    /// 
+    /// <param name="configure">
+    /// Optional delegate to configure underlying <see cref="HttpClient"/>.
+    /// </param>
+    /// 
+    /// <exception cref="ArgumentNullException">
+    /// When <paramref name="apiToken"/> is <see langword="null"/>.
+    /// </exception>
+    public MailtrapClientFactory(
+        string apiToken,
+        Action<IHttpClientBuilder>? configure = default)
+        : this(new MailtrapClientOptions(apiToken), configure)
+    { }
+
+    /// <summary>
+    /// Shortcut constructor to create a new instance of <see cref="MailtrapClientFactory"/>
+    /// using provided <paramref name="apiToken"/>
+    /// and preconfigured external <see cref="HttpClient"/> instance.
+    /// <para>
+    /// All other configuration settings will be set to default values.
+    /// </para>
+    /// </summary>
+    /// 
+    /// <param name="apiToken">
+    /// API authentication token.
+    /// </param>
+    /// 
+    /// <param name="httpClient">
+    /// External <see cref="HttpClient"/> instance to use within factory.
+    /// </param>
+    /// 
+    /// <exception cref="ArgumentNullException">
+    /// When <paramref name="apiToken"/> or <paramref name="httpClient"/> is <see langword="null"/>.
+    /// </exception>
+    ///
+    /// <remarks>
+    /// Factory won't dispose captured <paramref name="httpClient"/> instance upon disposal,
+    /// so it is responsibility of the caller to manage its lifecycle properly.
+    /// </remarks>
+    public MailtrapClientFactory(
+        string apiToken,
+        HttpClient httpClient)
+        : this(new MailtrapClientOptions(apiToken), httpClient)
+    { }
+
+    #endregion
+
+
+
+    #region IMailtrapClientFactory
+
+    /// <inheritdoc/>
+    public IMailtrapClient CreateClient() => _serviceProvider.GetRequiredService<IMailtrapClient>();
+
+    #endregion
+
+
+
+    #region IDisposable
+
+    /// <summary>
+    /// Disposes internal <see cref="IServiceProvider"/> instance,
+    /// that is used to spawn <see cref="IMailtrapClient"/> implementation instances.
+    /// </summary>
+    public void Dispose() => _serviceProvider.Dispose();
+
+    #endregion
+}


### PR DESCRIPTION
## Motivation
We might provide a way for SDK consumers to spawn client instances when using DI isn't possible or desired.  
Or for the sake of simplicity.

## Description of Changes
- Introduced `MailtrapClientFactory` implementation to spawn client instances.
- Added unit tests for it.

## Remarks
- Documentation with usage samples available in [configure](https://github.com/railsware/mailtrap-dotnet/blob/main/docs/cookbook/configure.md#standalone-factory) section.
- PR is based on #16 

## Checklist
- [x] Acknowledged that contribution is made under the project's [LICENSE](https://github.com/mailtrap/mailtrap-dotnet/blob/main/LICENSE.md)
- [x] Confirmed that PR and code/documentation changes are following the [Contributor Code of Conduct](https://github.com/mailtrap/mailtrap-dotnet/blob/main/CODE_OF_CONDUCT.md)
- [x] PR is properly titled and contains the summary of changes introduced
- [ ] PR branch is based on the latest main branch commit
- [x] PR contains some meaningful changes, including, but not limited to: functionality, tests, documentation, spelling, etc.
- [x] Added/updated XMLDoc and inline comments in the code, according to the changes made
- [x] Added/updated unit tests for added/changed functionality (if any)
- [x] Added/updated documentation files (if applicable)
