### PR TITLE
Fix API reference docs generation

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -3,9 +3,9 @@
     {
       "src": [
         {
-          "src": "../src/lib",
+          "src": "../src",
           "files": "**/*.csproj",
-          "exclude": [ "**/bin/**", "**/obj/**", "**/*.[Tt]ests.csproj" ]
+          "exclude": [ "**/bin/**", "**/obj/**" ]
         }
       ],
       "dest": "../artifacts/api",

--- a/docs/filter.yml
+++ b/docs/filter.yml
@@ -1,15 +1,31 @@
 ﻿### YamlMime:ManagedReference
 
 apiRules:
+- include:
+    uidRegex: ^System\.Object\.GetHashCode
+    type: Member
+- include:
+    uidRegex: ^System\.Object\.ToString
+    type: Member
+- include:
+    uidRegex: ^System\.Object\.Equals
+    type: Member
 - exclude:
-      uidRegex: ^System\.Object
-      type: Type
+    uidRegex: ^System\.Object
+    type: Type
+
 - include:
-      uidRegex: ^System\.Object\.GetHashCode
-      type: Method
+    uidRegex: ^System\.Exception\.Message
+    type: Member
 - include:
-      uidRegex: ^System\.Object\.ToString
-      type: Method
+    uidRegex: ^System\.Exception\.InnerException
+    type: Member
 - include:
-      uidRegex: ^System\.Object\.Equals
-      type: Method
+    uidRegex: ^System\.Exception\.Source
+    type: Member
+- include:
+    uidRegex: ^System\.Exception\.ToString
+    type: Member
+- exclude:
+    uidRegex: ^System\.Exception
+    type: Type


### PR DESCRIPTION
## Motivation
Previous commit changed the base code path - thus documentation generation was accidentally broken.

## Description of Changes
Fixed paths in DocFX config.

## Checklist
- [x] Acknowledged that contribution is made under the project's [LICENSE](https://github.com/mailtrap/mailtrap-dotnet/blob/main/LICENSE.md)
- [x] Confirmed that PR and code/documentation changes are following the [Contributor Code of Conduct](https://github.com/mailtrap/mailtrap-dotnet/blob/main/CODE_OF_CONDUCT.md)
- [x] PR is properly titled and contains the summary of changes introduced
- [x] PR branch is based on the latest main branch commit
- [x] PR contains some meaningful changes, including, but not limited to: functionality, tests, documentation, spelling, etc.
- [x] Added/updated XMLDoc and inline comments in the code, according to the changes made
- [x] Added/updated unit tests for added/changed functionality (if any)
- [x] Added/updated documentation files (if applicable)
