### PR TITLE
Feature - Add 'Reply To' field support to Send Email

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -274,7 +274,7 @@ dotnet_diagnostic.IDE0045.severity = suggestion
 dotnet_diagnostic.IDE0046.severity = suggestion
 
 # IDE0058: Expression value is never used
-dotnet_diagnostic.IDE0058.severity = suggestion
+dotnet_diagnostic.IDE0058.severity = silent
 
 
 # CA1032: Implement standard exception constructors

--- a/docs/cookbook/send-email.md
+++ b/docs/cookbook/send-email.md
@@ -40,6 +40,7 @@ var from = new EmailAddress("john.doe@demomailtrap.com", "John Doe");
 var request = new SendEmailRequest
 {
     From = from,
+    ReplyTo = new EmailAddress("noreply@milkyway.gov"),
     Subject = "Invitation to Earth",
     TextBody = "Dear Bill,\n\nIt will be a great pleasure to see you on our blue planet next weekend.\n\nBest regards, John."
 };
@@ -129,6 +130,9 @@ var request = SendEmailRequest.Create();
 
 // Sender (Display name is optional)
 request.From("john.doe@demomailtrap.com", "John Doe");
+
+// Reply To (Display name is optional)
+request.ReplyTo("no-reply@example.com");
 
 // You can use simple email as recipient
 request.To("hero.bill@galaxy.net");

--- a/examples/Mailtrap.Example.Email.Send/Program.cs
+++ b/examples/Mailtrap.Example.Email.Send/Program.cs
@@ -180,6 +180,8 @@ internal sealed class Program
         request.Cc.Add(new("ursa@ursamajor.gov"));
         request.Bcc.Add(new("aliens@milkyway.net"));
 
+        request.ReplyTo = new("no-reply@earth.com");
+
         // HTML body.
         // At least one of the Text or Html body must be specified.
         request.HtmlBody =
@@ -234,9 +236,8 @@ internal sealed class Program
         // Sender (Display name is optional)
         request.From("john.doe@demomailtrap.com", "John Doe");
 
-        // Alternatively, you can set the property directly
-        request.From = new("john.doe@demomailtrap.com", "John Doe");
-
+        // Reply To
+        request.ReplyTo("info@domain.com");
 
         // You can use simple email as recipient
         request.To("hero.bill@galaxy.net");
@@ -249,7 +250,9 @@ internal sealed class Program
         request.Cc(vipEmail);
 
         // Alternatively, you could pass a collection at once
-        request.Bcc(new EmailAddress("first@domain.com"), new EmailAddress("second@domain.com"));
+        request.Bcc(
+            new EmailAddress("first@domain.com"),
+            new EmailAddress("second@domain.com"));
 
         // Subject
         request.Subject("Invitation to Earth");

--- a/src/Mailtrap.Abstractions/Emails/Requests/SendEmailRequest.cs
+++ b/src/Mailtrap.Abstractions/Emails/Requests/SendEmailRequest.cs
@@ -26,8 +26,19 @@ public sealed record SendEmailRequest : IValidatable
     /// Instance, representing email's sender address and name.
     /// </value>
     [JsonPropertyName("from")]
-    [JsonPropertyOrder(1)]
+    [JsonPropertyOrder(10)]
     public EmailAddress? From { get; set; }
+
+    /// <summary>
+    /// Gets or sets <see cref="EmailAddress"/> representing 'Reply To' email field.
+    /// </summary>
+    /// 
+    /// <value>
+    /// Representing 'Reply To' address and name.
+    /// </value>
+    [JsonPropertyName("reply_to")]
+    [JsonPropertyOrder(15)]
+    public EmailAddress? ReplyTo { get; set; }
 
     /// <summary>
     /// Gets a collection of <see cref="EmailAddress"/> objects, defining who will receive a copy of email.
@@ -44,7 +55,7 @@ public sealed record SendEmailRequest : IValidatable
     /// At least one recipient must be specified in one of the collections: <see cref="To"/>, <see cref="Cc"/> or <see cref="Bcc"/>.
     /// </remarks>
     [JsonPropertyName("to")]
-    [JsonPropertyOrder(2)]
+    [JsonPropertyOrder(20)]
     [JsonObjectCreationHandling(JsonObjectCreationHandling.Populate)]
     public IList<EmailAddress> To { get; } = [];
 
@@ -63,7 +74,7 @@ public sealed record SendEmailRequest : IValidatable
     /// At least one recipient must be specified in one of the collections: <see cref="To"/>, <see cref="Cc"/> or <see cref="Bcc"/>.
     /// </remarks>
     [JsonPropertyName("cc")]
-    [JsonPropertyOrder(3)]
+    [JsonPropertyOrder(30)]
     [JsonObjectCreationHandling(JsonObjectCreationHandling.Populate)]
     public IList<EmailAddress> Cc { get; } = [];
 
@@ -82,7 +93,7 @@ public sealed record SendEmailRequest : IValidatable
     /// At least one recipient must be specified in one of the collections: <see cref="To"/>, <see cref="Cc"/> or <see cref="Bcc"/>.
     /// </remarks>
     [JsonPropertyName("bcc")]
-    [JsonPropertyOrder(4)]
+    [JsonPropertyOrder(40)]
     [JsonObjectCreationHandling(JsonObjectCreationHandling.Populate)]
     public IList<EmailAddress> Bcc { get; } = [];
 
@@ -94,7 +105,7 @@ public sealed record SendEmailRequest : IValidatable
     /// A collection of <see cref="Attachment"/> objects.
     /// </value>
     [JsonPropertyName("attachments")]
-    [JsonPropertyOrder(5)]
+    [JsonPropertyOrder(50)]
     [JsonObjectCreationHandling(JsonObjectCreationHandling.Populate)]
     public IList<Attachment> Attachments { get; } = [];
 
@@ -113,7 +124,7 @@ public sealed record SendEmailRequest : IValidatable
     /// "Content-Transfer-Encoding" header will be ignored and replaced with "quoted-printable".
     /// </remarks>
     [JsonPropertyName("headers")]
-    [JsonPropertyOrder(6)]
+    [JsonPropertyOrder(60)]
     [JsonObjectCreationHandling(JsonObjectCreationHandling.Populate)]
     public IDictionary<string, string> Headers { get; } = new Dictionary<string, string>();
 
@@ -131,7 +142,7 @@ public sealed record SendEmailRequest : IValidatable
     /// Total size of custom variables in JSON form must not exceed 1000 bytes.
     /// </remarks>
     [JsonPropertyName("custom_variables")]
-    [JsonPropertyOrder(7)]
+    [JsonPropertyOrder(70)]
     [JsonObjectCreationHandling(JsonObjectCreationHandling.Populate)]
     public IDictionary<string, string> CustomVariables { get; } = new Dictionary<string, string>();
 
@@ -152,7 +163,7 @@ public sealed record SendEmailRequest : IValidatable
     /// </para>
     /// </remarks>
     [JsonPropertyName("subject")]
-    [JsonPropertyOrder(8)]
+    [JsonPropertyOrder(80)]
     public string? Subject { get; set; }
 
     /// <summary>
@@ -169,7 +180,7 @@ public sealed record SendEmailRequest : IValidatable
     /// Required in the absence of <see cref="TemplateId"/> and <see cref="HtmlBody"/>.
     /// </remarks>
     [JsonPropertyName("text")]
-    [JsonPropertyOrder(9)]
+    [JsonPropertyOrder(90)]
     public string? TextBody { get; set; }
 
     /// <summary>
@@ -185,7 +196,7 @@ public sealed record SendEmailRequest : IValidatable
     /// Required in the absence of <see cref="TemplateId"/> and <see cref="TextBody"/>.
     /// </remarks>
     [JsonPropertyName("html")]
-    [JsonPropertyOrder(10)]
+    [JsonPropertyOrder(100)]
     public string? HtmlBody { get; set; }
 
     /// <summary>
@@ -201,7 +212,7 @@ public sealed record SendEmailRequest : IValidatable
     /// Otherwise must be less or equal to 255 characters.
     /// </remarks>
     [JsonPropertyName("category")]
-    [JsonPropertyOrder(11)]
+    [JsonPropertyOrder(110)]
     public string? Category { get; set; }
 
     /// <summary>
@@ -218,7 +229,7 @@ public sealed record SendEmailRequest : IValidatable
     /// Email subject, text and html will be generated from template using optional <see cref="TemplateVariables"/>.
     /// </remarks>
     [JsonPropertyName("template_uuid")]
-    [JsonPropertyOrder(12)]
+    [JsonPropertyOrder(120)]
     public string? TemplateId { get; set; }
 
     /// <summary>
@@ -234,7 +245,7 @@ public sealed record SendEmailRequest : IValidatable
     /// Will be used only in case <see cref="TemplateId"/> is set.
     /// </remarks>
     [JsonPropertyName("template_variables")]
-    [JsonPropertyOrder(13)]
+    [JsonPropertyOrder(130)]
     public object? TemplateVariables { get; set; }
 
 

--- a/src/Mailtrap.Abstractions/Emails/Validators/SendEmailRequestValidator.cs
+++ b/src/Mailtrap.Abstractions/Emails/Validators/SendEmailRequestValidator.cs
@@ -16,6 +16,10 @@ internal sealed class SendEmailRequestValidator : AbstractValidator<SendEmailReq
     {
         RuleFor(r => r.From!).NotNull().SetValidator(EmailAddressValidator.Instance);
 
+        RuleFor(r => r.ReplyTo!)
+            .SetValidator(EmailAddressValidator.Instance)
+            .When(r => r.ReplyTo is not null);
+
         RuleFor(r => r.To).Must(r => r.Count is <= 1000);
         RuleForEach(r => r.To).SetValidator(EmailAddressValidator.Instance);
 

--- a/src/Mailtrap/Emails/Requests/SendEmailRequestBuilder.cs
+++ b/src/Mailtrap/Emails/Requests/SendEmailRequestBuilder.cs
@@ -93,6 +93,85 @@ public static class SendEmailRequestBuilder
 
 
 
+    #region Reply To
+
+    /// <summary>
+    /// Sets provided <paramref name="replyTo"/> address in the <paramref name="request"/>.
+    /// </summary>
+    ///
+    /// <param name="request">
+    /// <see cref="SendEmailRequest"/> instance to update.
+    /// </param>
+    ///
+    /// <param name="replyTo">
+    /// <see cref="EmailAddress"/> object to initialize request's <see cref="SendEmailRequest.ReplyTo"/> property.
+    /// </param>
+    ///
+    /// <returns>
+    /// Updated <see cref="SendEmailRequest"/> instance so subsequent calls can be chained.
+    /// </returns>
+    /// 
+    /// <exception cref="ArgumentNullException">
+    /// When <paramref name="request"/> is <see langword="null"/>.
+    /// </exception>
+    ///
+    /// <remarks>
+    /// Subsequent calls will override value that was set before (last wins).
+    /// </remarks>
+    public static SendEmailRequest ReplyTo(this SendEmailRequest request, EmailAddress? replyTo)
+    {
+        Ensure.NotNull(request, nameof(request));
+
+        request.ReplyTo = replyTo;
+
+        return request;
+    }
+
+    /// <summary>
+    /// Sets provided <paramref name="email"/> and <paramref name="displayName"/> as 'Reply To' address
+    /// in the <paramref name="request"/>.
+    /// </summary>
+    ///
+    /// <param name="request">
+    /// <inheritdoc cref="ReplyTo(SendEmailRequest, EmailAddress?)" path="/param[@name='request']"/>
+    /// </param>
+    ///
+    /// <param name="email">
+    /// <para>
+    /// 'Reply To' email address.
+    /// </para>
+    /// <para>
+    /// Required. Must be valid email address.
+    /// </para>
+    /// </param>
+    /// 
+    /// <param name="displayName">
+    /// Optional 'Reply To' display name.
+    /// </param>
+    ///
+    /// <returns>
+    /// <inheritdoc cref="ReplyTo(SendEmailRequest, EmailAddress?)" path="/returns"/>
+    /// </returns>
+    /// 
+    /// <exception cref="ArgumentNullException">
+    /// When <paramref name="request"/> is <see langword="null"/>.<br />
+    /// When <paramref name="email"/> is <see langword="null"/> or <see cref="string.Empty"/>.
+    /// </exception>
+    ///
+    /// <remarks>
+    /// <inheritdoc cref="ReplyTo(SendEmailRequest, EmailAddress?)" path="/remarks"/>
+    /// </remarks>
+    public static SendEmailRequest ReplyTo(this SendEmailRequest request, string email, string? displayName = default)
+    {
+        Ensure.NotNull(request, nameof(request));
+
+        return request.ReplyTo(new EmailAddress(email, displayName));
+    }
+
+    #endregion
+
+
+
     #region To
 
     /// <summary>

--- a/tests/Mailtrap.IntegrationTests/Emails/SendEmailIntegrationTests.cs
+++ b/tests/Mailtrap.IntegrationTests/Emails/SendEmailIntegrationTests.cs
@@ -287,9 +287,7 @@ internal sealed class SendEmailIntegrationTests
             .WithHeaders("Authorization", $"Bearer {config.ApiToken}")
             .WithHeaders("Accept", MimeTypes.Application.Json)
             .WithHeaders("User-Agent", HeaderValues.UserAgent.ToString())
-            .With(r =>
-                r.Content?.Headers.Contains("Content-Type") == true &&
-                r.Content?.Headers.ContentType?.MediaType == MimeTypes.Application.Json)
+            .With(r => r.Content?.Headers.ContentType?.MediaType == MimeTypes.Application.Json)
             .Respond(HttpStatusCode.OK, responseContent);
 
         serviceCollection

--- a/tests/Mailtrap.UnitTests/Emails/EmailClientEndpointProviderTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/EmailClientEndpointProviderTests.cs
@@ -5,7 +5,7 @@
 // -----------------------------------------------------------------------
 
 
-namespace Mailtrap.UnitTests.Email;
+namespace Mailtrap.UnitTests.Emails;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/EmailClientFactoryTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/EmailClientFactoryTests.cs
@@ -5,7 +5,7 @@
 // -----------------------------------------------------------------------
 
 
-namespace Mailtrap.UnitTests.Email;
+namespace Mailtrap.UnitTests.Emails;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/EmailClientTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/EmailClientTests.cs
@@ -5,7 +5,7 @@
 // -----------------------------------------------------------------------
 
 
-namespace Mailtrap.UnitTests.Email;
+namespace Mailtrap.UnitTests.Emails;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/Models/AttachmentTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Models/AttachmentTests.cs
@@ -5,7 +5,7 @@
 // -----------------------------------------------------------------------
 
 
-namespace Mailtrap.UnitTests.Email.Models;
+namespace Mailtrap.UnitTests.Emails.Models;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/Models/EmailAddressTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Models/EmailAddressTests.cs
@@ -5,7 +5,7 @@
 // -----------------------------------------------------------------------
 
 
-namespace Mailtrap.UnitTests.Email.Models;
+namespace Mailtrap.UnitTests.Emails.Models;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Attachment.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Attachment.cs
@@ -4,7 +4,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Mailtrap.UnitTests.Email.Requests;
+
+namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Bcc.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Bcc.cs
@@ -1,14 +1,15 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilderTests.To.cs" company="Railsware Products Studio, LLC">
+// <copyright file="SendEmailRequestBuilderTests.Bcc.cs" company="Railsware Products Studio, LLC">
 // Copyright (c) Railsware Products Studio, LLC. All rights reserved.
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Mailtrap.UnitTests.Email.Requests;
+
+namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]
-internal sealed class SendEmailRequestBuilderTests_To
+internal sealed class SendEmailRequestBuilderTests_Bcc
 {
     private string RecipientEmail { get; } = "recipient@domain.com";
     private string RecipientDisplayName { get; } = "Recipient";
@@ -17,77 +18,77 @@ internal sealed class SendEmailRequestBuilderTests_To
 
 
 
-    #region To
+    #region Bcc
 
     [Test]
-    public void To_ShouldThrowArgumentNullException_WhenRequestIsNull()
+    public void Bcc_ShouldThrowArgumentNullException_WhenRequestIsNull()
     {
-        var act = () => SendEmailRequestBuilder.To(null!, _recipient1);
+        var act = () => SendEmailRequestBuilder.Bcc(null!, _recipient1);
 
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Test]
-    public void To_ShouldThrowArgumentNullException_WhenParamsIsNull()
+    public void Bcc_ShouldThrowArgumentNullException_WhenParamsIsNull()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => request.To(null!);
+        var act = () => request.Bcc(null!);
 
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Test]
-    public void To_ShouldNotThrowException_WhenParamsIsEmpty()
+    public void Bcc_ShouldNotThrowException_WhenParamsIsEmpty()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => request.To([]);
+        var act = () => request.Bcc([]);
 
         act.Should().NotThrow();
     }
 
     [Test]
-    public void To_ShouldAddRecipientsToCollection()
+    public void Bcc_ShouldAddRecipientsToCollection()
     {
-        To_CreateAndValidate(_recipient1, _recipient2);
+        Bcc_CreateAndValidate(_recipient1, _recipient2);
     }
 
     [Test]
-    public void To_ShouldAddRecipientsToCollection_WhenCalledMultipleTimes()
+    public void Bcc_ShouldAddRecipientsToCollection_WhenCalledMultipleTimes()
     {
         var recipient3 = new EmailAddress("recipient3@domain.com");
         var recipient4 = new EmailAddress("recipient4@domain.com", "Recipient 4");
 
-        var request = To_CreateAndValidate(_recipient1, _recipient2);
+        var request = Bcc_CreateAndValidate(_recipient1, _recipient2);
 
-        request.To(recipient3, recipient4);
+        request.Bcc(recipient3, recipient4);
 
-        request.To.Should()
+        request.Bcc.Should()
             .HaveCount(4).And
             .ContainInOrder(_recipient1, _recipient2, recipient3, recipient4);
     }
 
     [Test]
-    public void To_ShouldNotAddRecipientsToCollection_WhenParamsIsEmpty()
+    public void Bcc_ShouldNotAddRecipientsToCollection_WhenParamsIsEmpty()
     {
-        var request = To_CreateAndValidate(_recipient1, _recipient2);
+        var request = Bcc_CreateAndValidate(_recipient1, _recipient2);
 
-        request.To([]);
+        request.Bcc([]);
 
-        request.To.Should()
+        request.Bcc.Should()
             .HaveCount(2).And
             .ContainInOrder(_recipient1, _recipient2);
     }
 
 
-    private static SendEmailRequest To_CreateAndValidate(params EmailAddress[] recipients)
+    private static SendEmailRequest Bcc_CreateAndValidate(params EmailAddress[] recipients)
     {
         var request = SendEmailRequest
             .Create()
-            .To(recipients);
+            .Bcc(recipients);
 
-        request.To.Should()
+        request.Bcc.Should()
             .HaveCount(2).And
             .ContainInOrder(recipients);
 
@@ -98,81 +99,81 @@ internal sealed class SendEmailRequestBuilderTests_To
 
 
 
-    #region To(email, displayName)
+    #region Bcc(email, displayName)
     [Test]
-    public void To_ShouldThrowArgumentNullException_WhenRequestIsNull_2()
+    public void Bcc_ShouldThrowArgumentNullException_WhenRequestIsNull_2()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => SendEmailRequestBuilder.To(null!, RecipientEmail);
+        var act = () => SendEmailRequestBuilder.Bcc(null!, RecipientEmail);
 
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Test]
-    public void To_ShouldThrowArgumentNullException_WhenRecipientEmailIsNull()
+    public void Bcc_ShouldThrowArgumentNullException_WhenRecipientEmailIsNull()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => request.To(null!, RecipientDisplayName);
+        var act = () => request.Bcc(null!, RecipientDisplayName);
 
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Test]
-    public void To_ShouldThrowArgumentNullException_WhenRecipientEmailIsEmpty()
+    public void Bcc_ShouldThrowArgumentNullException_WhenRecipientEmailIsEmpty()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => request.To(string.Empty, RecipientDisplayName);
+        var act = () => request.Bcc(string.Empty, RecipientDisplayName);
 
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Test]
-    public void To_ShouldNotThrowException_WhenRecipientDisplayNameIsNull()
+    public void Bcc_ShouldNotThrowException_WhenRecipientDisplayNameIsNull()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => request.To(RecipientEmail, null);
+        var act = () => request.Bcc(RecipientEmail, null);
+
+        act.Should().NotThrow();
+    }
+
+    [TestCase]
+    public void Bcc_ShouldNotThrowException_WhenRecipientDisplayNameIsEmpty()
+    {
+        var request = SendEmailRequest.Create();
+
+        var act = () => request.Bcc(RecipientEmail, string.Empty);
 
         act.Should().NotThrow();
     }
 
     [Test]
-    public void To_ShouldNotThrowException_WhenRecipientDisplayNameIsEmpty()
-    {
-        var request = SendEmailRequest.Create();
-
-        var act = () => request.To(RecipientEmail, string.Empty);
-
-        act.Should().NotThrow();
-    }
-
-    [Test]
-    public void To_ShouldAddRecipientToCollection_WhenOnlyEmailProvided()
+    public void Bcc_ShouldAddRecipientToCollection_WhenOnlyEmailProvided()
     {
         var request = SendEmailRequest
             .Create()
-            .To(RecipientEmail);
+            .Bcc(RecipientEmail);
 
-        request.To.Should().ContainSingle();
+        request.Bcc.Should().ContainSingle();
 
-        var added = request.To.First();
+        var added = request.Bcc.First();
         added.Email.Should().Be(RecipientEmail);
         added.DisplayName.Should().BeNull();
     }
 
     [Test]
-    public void To_ShouldAddRecipientToCollection_WhenFullInfoProvided()
+    public void Bcc_ShouldAddRecipientToCollection_WhenFullInfoProvided()
     {
         var request = SendEmailRequest
             .Create()
-            .To(RecipientEmail, RecipientDisplayName);
+            .Bcc(RecipientEmail, RecipientDisplayName);
 
-        request.To.Should().ContainSingle();
+        request.Bcc.Should().ContainSingle();
 
-        var added = request.To.First();
+        var added = request.Bcc.First();
         added.Email.Should().Be(RecipientEmail);
         added.DisplayName.Should().Be(RecipientDisplayName);
     }

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Category.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Category.cs
@@ -4,7 +4,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Mailtrap.UnitTests.Email.Requests;
+
+namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Cc.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Cc.cs
@@ -1,14 +1,15 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilderTests.Bcc.cs" company="Railsware Products Studio, LLC">
+// <copyright file="SendEmailRequestBuilderTests.Cc.cs" company="Railsware Products Studio, LLC">
 // Copyright (c) Railsware Products Studio, LLC. All rights reserved.
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Mailtrap.UnitTests.Email.Requests;
+
+namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]
-internal sealed class SendEmailRequestBuilderTests_Bcc
+internal sealed class SendEmailRequestBuilderTests_Cc
 {
     private string RecipientEmail { get; } = "recipient@domain.com";
     private string RecipientDisplayName { get; } = "Recipient";
@@ -17,77 +18,77 @@ internal sealed class SendEmailRequestBuilderTests_Bcc
 
 
 
-    #region Bcc
+    #region Cc
 
     [Test]
-    public void Bcc_ShouldThrowArgumentNullException_WhenRequestIsNull()
+    public void Cc_ShouldThrowArgumentNullException_WhenRequestIsNull()
     {
-        var act = () => SendEmailRequestBuilder.Bcc(null!, _recipient1);
+        var act = () => SendEmailRequestBuilder.Cc(null!, _recipient1);
 
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Test]
-    public void Bcc_ShouldThrowArgumentNullException_WhenParamsIsNull()
+    public void Cc_ShouldThrowArgumentNullException_WhenParamsIsNull()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => request.Bcc(null!);
+        var act = () => request.Cc(null!);
 
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Test]
-    public void Bcc_ShouldNotThrowException_WhenParamsIsEmpty()
+    public void Cc_ShouldNotThrowException_WhenParamsIsEmpty()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => request.Bcc([]);
+        var act = () => request.Cc([]);
 
         act.Should().NotThrow();
     }
 
     [Test]
-    public void Bcc_ShouldAddRecipientsToCollection()
+    public void Cc_ShouldAddRecipientsToCollection()
     {
-        Bcc_CreateAndValidate(_recipient1, _recipient2);
+        Cc_CreateAndValidate(_recipient1, _recipient2);
     }
 
     [Test]
-    public void Bcc_ShouldAddRecipientsToCollection_WhenCalledMultipleTimes()
+    public void Cc_ShouldAddRecipientsToCollection_WhenCalledMultipleTimes()
     {
         var recipient3 = new EmailAddress("recipient3@domain.com");
         var recipient4 = new EmailAddress("recipient4@domain.com", "Recipient 4");
 
-        var request = Bcc_CreateAndValidate(_recipient1, _recipient2);
+        var request = Cc_CreateAndValidate(_recipient1, _recipient2);
 
-        request.Bcc(recipient3, recipient4);
+        request.Cc(recipient3, recipient4);
 
-        request.Bcc.Should()
+        request.Cc.Should()
             .HaveCount(4).And
             .ContainInOrder(_recipient1, _recipient2, recipient3, recipient4);
     }
 
     [Test]
-    public void Bcc_ShouldNotAddRecipientsToCollection_WhenParamsIsEmpty()
+    public void Cc_ShouldNotAddRecipientsToCollection_WhenParamsIsEmpty()
     {
-        var request = Bcc_CreateAndValidate(_recipient1, _recipient2);
+        var request = Cc_CreateAndValidate(_recipient1, _recipient2);
 
-        request.Bcc([]);
+        request.Cc([]);
 
-        request.Bcc.Should()
+        request.Cc.Should()
             .HaveCount(2).And
             .ContainInOrder(_recipient1, _recipient2);
     }
 
 
-    private static SendEmailRequest Bcc_CreateAndValidate(params EmailAddress[] recipients)
+    private static SendEmailRequest Cc_CreateAndValidate(params EmailAddress[] recipients)
     {
         var request = SendEmailRequest
             .Create()
-            .Bcc(recipients);
+            .Cc(recipients);
 
-        request.Bcc.Should()
+        request.Cc.Should()
             .HaveCount(2).And
             .ContainInOrder(recipients);
 
@@ -98,81 +99,82 @@ internal sealed class SendEmailRequestBuilderTests_Bcc
 
 
 
-    #region Bcc(email, displayName)
+    #region Cc(email, displayName)
+
     [Test]
-    public void Bcc_ShouldThrowArgumentNullException_WhenRequestIsNull_2()
+    public void Cc_ShouldThrowArgumentNullException_WhenRequestIsNull_2()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => SendEmailRequestBuilder.Bcc(null!, RecipientEmail);
+        var act = () => SendEmailRequestBuilder.Cc(null!, RecipientEmail);
 
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Test]
-    public void Bcc_ShouldThrowArgumentNullException_WhenRecipientEmailIsNull()
+    public void Cc_ShouldThrowArgumentNullException_WhenRecipientEmailIsNull()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => request.Bcc(null!, RecipientDisplayName);
+        var act = () => request.Cc(null!, RecipientDisplayName);
 
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Test]
-    public void Bcc_ShouldThrowArgumentNullException_WhenRecipientEmailIsEmpty()
+    public void Cc_ShouldThrowArgumentNullException_WhenRecipientEmailIsEmpty()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => request.Bcc(string.Empty, RecipientDisplayName);
+        var act = () => request.Cc(string.Empty, RecipientDisplayName);
 
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Test]
-    public void Bcc_ShouldNotThrowException_WhenRecipientDisplayNameIsNull()
+    public void Cc_ShouldNotThrowException_WhenRecipientDisplayNameIsNull()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => request.Bcc(RecipientEmail, null);
+        var act = () => request.Cc(RecipientEmail, null);
 
         act.Should().NotThrow();
     }
 
     [TestCase]
-    public void Bcc_ShouldNotThrowException_WhenRecipientDisplayNameIsEmpty()
+    public void Cc_ShouldNotThrowException_WhenRecipientDisplayNameIsEmpty()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => request.Bcc(RecipientEmail, string.Empty);
+        var act = () => request.Cc(RecipientEmail, string.Empty);
 
         act.Should().NotThrow();
     }
 
     [Test]
-    public void Bcc_ShouldAddRecipientToCollection_WhenOnlyEmailProvided()
+    public void Cc_ShouldAddRecipientToCollection_WhenOnlyEmailProvided()
     {
         var request = SendEmailRequest
             .Create()
-            .Bcc(RecipientEmail);
+            .Cc(RecipientEmail);
 
-        request.Bcc.Should().ContainSingle();
+        request.Cc.Should().ContainSingle();
 
-        var added = request.Bcc.First();
+        var added = request.Cc.First();
         added.Email.Should().Be(RecipientEmail);
         added.DisplayName.Should().BeNull();
     }
 
     [Test]
-    public void Bcc_ShouldAddRecipientToCollection_WhenFullInfoProvided()
+    public void Cc_ShouldAddRecipientToCollection_WhenFullInfoProvided()
     {
         var request = SendEmailRequest
             .Create()
-            .Bcc(RecipientEmail, RecipientDisplayName);
+            .Cc(RecipientEmail, RecipientDisplayName);
 
-        request.Bcc.Should().ContainSingle();
+        request.Cc.Should().ContainSingle();
 
-        var added = request.Bcc.First();
+        var added = request.Cc.First();
         added.Email.Should().Be(RecipientEmail);
         added.DisplayName.Should().Be(RecipientDisplayName);
     }

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.CustomVariable.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.CustomVariable.cs
@@ -8,7 +8,7 @@
 using Variable = System.Collections.Generic.KeyValuePair<string, string>;
 
 
-namespace Mailtrap.UnitTests.Email.Requests;
+namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.From.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.From.cs
@@ -4,7 +4,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Mailtrap.UnitTests.Email.Requests;
+
+namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Header.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Header.cs
@@ -8,7 +8,7 @@
 using Header = System.Collections.Generic.KeyValuePair<string, string>;
 
 
-namespace Mailtrap.UnitTests.Email.Requests;
+namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.HtmlBody.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.HtmlBody.cs
@@ -4,7 +4,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Mailtrap.UnitTests.Email.Requests;
+
+namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.ReplyTo.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.ReplyTo.cs
@@ -1,0 +1,157 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="SendEmailRequestBuilderTests.ReplyTo.cs" company="Railsware Products Studio, LLC">
+// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+
+namespace Mailtrap.UnitTests.Emails.Requests;
+
+
+[TestFixture(TestOf = typeof(SendEmailRequestBuilder))]
+internal sealed class SendEmailRequestBuilderTests_ReplyTo
+{
+    private string ReplyToEmail { get; } = "reply.to@domain.com";
+    private string ReplyToDisplayName { get; } = "Reply To";
+    private EmailAddress _replyTo { get; } = new("reply.to@domain.com", "Reply To");
+
+
+    #region ReplyTo(sender)
+
+    [Test]
+    public void ReplyTo_ShouldThrowArgumentNullException_WhenRequestIsNull()
+    {
+        var act = () => SendEmailRequestBuilder.ReplyTo(null!, _replyTo);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void ReplyTo_ShouldAssignReplyToProperly_WhenNull()
+    {
+        var request = SendEmailRequest
+            .Create()
+            .ReplyTo(null);
+
+        request.ReplyTo.Should().BeNull();
+    }
+
+    [Test]
+    public void ReplyTo_ShouldAssignReplyToProperly()
+    {
+        var request = SendEmailRequest
+            .Create()
+            .ReplyTo(_replyTo);
+
+        request.ReplyTo.Should().BeSameAs(_replyTo);
+    }
+
+    [Test]
+    public void ReplyTo_ShouldOverride_WhenCalledSeveralTimes()
+    {
+        var otherReplyTo = new EmailAddress("replyTo2@domain.com", "Reply To 2");
+
+        var request = SendEmailRequest
+            .Create()
+            .ReplyTo(_replyTo)
+            .ReplyTo(otherReplyTo);
+
+        request.ReplyTo.Should().BeSameAs(otherReplyTo);
+    }
+
+    #endregion
+
+
+    #region ReplyTo(email, displayName)
+
+    [Test]
+    public void ReplyTo_ShouldThrowArgumentNullException_WhenRequestIsNull_2()
+    {
+        var request = SendEmailRequest.Create();
+
+        var act = () => SendEmailRequestBuilder.ReplyTo(null!, ReplyToEmail);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void ReplyTo_ShouldThrowArgumentNullException_WhenReplyToEmailIsNull()
+    {
+        var request = SendEmailRequest.Create();
+
+        var act = () => request.ReplyTo(null!, ReplyToDisplayName);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void ReplyTo_ShouldThrowArgumentNullException_WhenReplyToEmailIsEmpty()
+    {
+        var request = SendEmailRequest.Create();
+
+        var act = () => request.ReplyTo(string.Empty, ReplyToDisplayName);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void ReplyTo_ShouldNotThrowException_WhenReplyToDisplayNameIsNull()
+    {
+        var request = SendEmailRequest.Create();
+
+        var act = () => request.ReplyTo(ReplyToEmail, null);
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReplyTo_ShouldNotThrowException_WhenReplyToDisplayNameIsEmpty()
+    {
+        var request = SendEmailRequest.Create();
+
+        var act = () => request.ReplyTo(ReplyToEmail, string.Empty);
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ReplyTo_ShouldInitializeReplyToProperly_WhenOnlyEmailProvided()
+    {
+        var request = SendEmailRequest
+            .Create()
+            .ReplyTo(ReplyToEmail);
+
+        request.ReplyTo.Should().NotBeNull();
+        request.ReplyTo!.Email.Should().Be(ReplyToEmail);
+        request.ReplyTo!.DisplayName.Should().BeNull();
+    }
+
+    [Test]
+    public void ReplyTo_ShouldInitializeReplyToProperly_WhenFullInfoProvided()
+    {
+        var request = SendEmailRequest
+            .Create()
+            .ReplyTo(ReplyToEmail, ReplyToDisplayName);
+
+        request.ReplyTo.Should().NotBeNull();
+        request.ReplyTo!.Email.Should().Be(ReplyToEmail);
+        request.ReplyTo!.DisplayName.Should().Be(ReplyToDisplayName);
+    }
+
+    [Test]
+    public void ReplyTo_ShouldOverrideReplyTo_WhenCalledSeveralTimes_2()
+    {
+        var otherReplyToEmail = "replyTo2@domain.com";
+
+        var request = SendEmailRequest
+            .Create()
+            .ReplyTo(_replyTo)
+            .ReplyTo(otherReplyToEmail);
+
+        request.ReplyTo.Should().NotBeSameAs(_replyTo);
+        request.ReplyTo!.Email.Should().Be(otherReplyToEmail);
+        request.ReplyTo!.DisplayName.Should().BeNull();
+    }
+
+    #endregion
+}

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Subject.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Subject.cs
@@ -4,7 +4,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Mailtrap.UnitTests.Email.Requests;
+
+namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Template.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Template.cs
@@ -4,7 +4,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Mailtrap.UnitTests.Email.Requests;
+
+namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.TemplateVariables.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.TemplateVariables.cs
@@ -4,7 +4,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Mailtrap.UnitTests.Email.Requests;
+
+namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.TextBody.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.TextBody.cs
@@ -4,7 +4,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Mailtrap.UnitTests.Email.Requests;
+
+namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.To.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.To.cs
@@ -1,14 +1,15 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilderTests.Cc.cs" company="Railsware Products Studio, LLC">
+// <copyright file="SendEmailRequestBuilderTests.To.cs" company="Railsware Products Studio, LLC">
 // Copyright (c) Railsware Products Studio, LLC. All rights reserved.
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Mailtrap.UnitTests.Email.Requests;
+
+namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]
-internal sealed class SendEmailRequestBuilderTests_Cc
+internal sealed class SendEmailRequestBuilderTests_To
 {
     private string RecipientEmail { get; } = "recipient@domain.com";
     private string RecipientDisplayName { get; } = "Recipient";
@@ -17,77 +18,77 @@ internal sealed class SendEmailRequestBuilderTests_Cc
 
 
 
-    #region Cc
+    #region To
 
     [Test]
-    public void Cc_ShouldThrowArgumentNullException_WhenRequestIsNull()
+    public void To_ShouldThrowArgumentNullException_WhenRequestIsNull()
     {
-        var act = () => SendEmailRequestBuilder.Cc(null!, _recipient1);
+        var act = () => SendEmailRequestBuilder.To(null!, _recipient1);
 
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Test]
-    public void Cc_ShouldThrowArgumentNullException_WhenParamsIsNull()
+    public void To_ShouldThrowArgumentNullException_WhenParamsIsNull()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => request.Cc(null!);
+        var act = () => request.To(null!);
 
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Test]
-    public void Cc_ShouldNotThrowException_WhenParamsIsEmpty()
+    public void To_ShouldNotThrowException_WhenParamsIsEmpty()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => request.Cc([]);
+        var act = () => request.To([]);
 
         act.Should().NotThrow();
     }
 
     [Test]
-    public void Cc_ShouldAddRecipientsToCollection()
+    public void To_ShouldAddRecipientsToCollection()
     {
-        Cc_CreateAndValidate(_recipient1, _recipient2);
+        To_CreateAndValidate(_recipient1, _recipient2);
     }
 
     [Test]
-    public void Cc_ShouldAddRecipientsToCollection_WhenCalledMultipleTimes()
+    public void To_ShouldAddRecipientsToCollection_WhenCalledMultipleTimes()
     {
         var recipient3 = new EmailAddress("recipient3@domain.com");
         var recipient4 = new EmailAddress("recipient4@domain.com", "Recipient 4");
 
-        var request = Cc_CreateAndValidate(_recipient1, _recipient2);
+        var request = To_CreateAndValidate(_recipient1, _recipient2);
 
-        request.Cc(recipient3, recipient4);
+        request.To(recipient3, recipient4);
 
-        request.Cc.Should()
+        request.To.Should()
             .HaveCount(4).And
             .ContainInOrder(_recipient1, _recipient2, recipient3, recipient4);
     }
 
     [Test]
-    public void Cc_ShouldNotAddRecipientsToCollection_WhenParamsIsEmpty()
+    public void To_ShouldNotAddRecipientsToCollection_WhenParamsIsEmpty()
     {
-        var request = Cc_CreateAndValidate(_recipient1, _recipient2);
+        var request = To_CreateAndValidate(_recipient1, _recipient2);
 
-        request.Cc([]);
+        request.To([]);
 
-        request.Cc.Should()
+        request.To.Should()
             .HaveCount(2).And
             .ContainInOrder(_recipient1, _recipient2);
     }
 
 
-    private static SendEmailRequest Cc_CreateAndValidate(params EmailAddress[] recipients)
+    private static SendEmailRequest To_CreateAndValidate(params EmailAddress[] recipients)
     {
         var request = SendEmailRequest
             .Create()
-            .Cc(recipients);
+            .To(recipients);
 
-        request.Cc.Should()
+        request.To.Should()
             .HaveCount(2).And
             .ContainInOrder(recipients);
 
@@ -98,82 +99,81 @@ internal sealed class SendEmailRequestBuilderTests_Cc
 
 
 
-    #region Cc(email, displayName)
-
+    #region To(email, displayName)
     [Test]
-    public void Cc_ShouldThrowArgumentNullException_WhenRequestIsNull_2()
+    public void To_ShouldThrowArgumentNullException_WhenRequestIsNull_2()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => SendEmailRequestBuilder.Cc(null!, RecipientEmail);
+        var act = () => SendEmailRequestBuilder.To(null!, RecipientEmail);
 
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Test]
-    public void Cc_ShouldThrowArgumentNullException_WhenRecipientEmailIsNull()
+    public void To_ShouldThrowArgumentNullException_WhenRecipientEmailIsNull()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => request.Cc(null!, RecipientDisplayName);
+        var act = () => request.To(null!, RecipientDisplayName);
 
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Test]
-    public void Cc_ShouldThrowArgumentNullException_WhenRecipientEmailIsEmpty()
+    public void To_ShouldThrowArgumentNullException_WhenRecipientEmailIsEmpty()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => request.Cc(string.Empty, RecipientDisplayName);
+        var act = () => request.To(string.Empty, RecipientDisplayName);
 
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Test]
-    public void Cc_ShouldNotThrowException_WhenRecipientDisplayNameIsNull()
+    public void To_ShouldNotThrowException_WhenRecipientDisplayNameIsNull()
     {
         var request = SendEmailRequest.Create();
 
-        var act = () => request.Cc(RecipientEmail, null);
-
-        act.Should().NotThrow();
-    }
-
-    [TestCase]
-    public void Cc_ShouldNotThrowException_WhenRecipientDisplayNameIsEmpty()
-    {
-        var request = SendEmailRequest.Create();
-
-        var act = () => request.Cc(RecipientEmail, string.Empty);
+        var act = () => request.To(RecipientEmail, null);
 
         act.Should().NotThrow();
     }
 
     [Test]
-    public void Cc_ShouldAddRecipientToCollection_WhenOnlyEmailProvided()
+    public void To_ShouldNotThrowException_WhenRecipientDisplayNameIsEmpty()
+    {
+        var request = SendEmailRequest.Create();
+
+        var act = () => request.To(RecipientEmail, string.Empty);
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void To_ShouldAddRecipientToCollection_WhenOnlyEmailProvided()
     {
         var request = SendEmailRequest
             .Create()
-            .Cc(RecipientEmail);
+            .To(RecipientEmail);
 
-        request.Cc.Should().ContainSingle();
+        request.To.Should().ContainSingle();
 
-        var added = request.Cc.First();
+        var added = request.To.First();
         added.Email.Should().Be(RecipientEmail);
         added.DisplayName.Should().BeNull();
     }
 
     [Test]
-    public void Cc_ShouldAddRecipientToCollection_WhenFullInfoProvided()
+    public void To_ShouldAddRecipientToCollection_WhenFullInfoProvided()
     {
         var request = SendEmailRequest
             .Create()
-            .Cc(RecipientEmail, RecipientDisplayName);
+            .To(RecipientEmail, RecipientDisplayName);
 
-        request.Cc.Should().ContainSingle();
+        request.To.Should().ContainSingle();
 
-        var added = request.Cc.First();
+        var added = request.To.First();
         added.Email.Should().Be(RecipientEmail);
         added.DisplayName.Should().Be(RecipientDisplayName);
     }

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestTests.cs
@@ -4,7 +4,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Mailtrap.UnitTests.Email.Requests;
+
+namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/Responses/SendEmailResponseTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Responses/SendEmailResponseTests.cs
@@ -5,7 +5,7 @@
 // -----------------------------------------------------------------------
 
 
-namespace Mailtrap.UnitTests.Email.Responses;
+namespace Mailtrap.UnitTests.Emails.Responses;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/Validators/AttachmentValidatorTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Validators/AttachmentValidatorTests.cs
@@ -5,7 +5,7 @@
 // -----------------------------------------------------------------------
 
 
-namespace Mailtrap.UnitTests.Email.Validators;
+namespace Mailtrap.UnitTests.Emails.Validators;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/Validators/EmailAddressValidatorTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Validators/EmailAddressValidatorTests.cs
@@ -5,7 +5,7 @@
 // -----------------------------------------------------------------------
 
 
-namespace Mailtrap.UnitTests.Email.Validators;
+namespace Mailtrap.UnitTests.Emails.Validators;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/Validators/SendEmailRequestValidatorTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Validators/SendEmailRequestValidatorTests.cs
@@ -5,7 +5,7 @@
 // -----------------------------------------------------------------------
 
 
-namespace Mailtrap.UnitTests.Email.Validators;
+namespace Mailtrap.UnitTests.Emails.Validators;
 
 
 [TestFixture]
@@ -94,6 +94,48 @@ internal sealed class SendEmailRequestValidatorTests
 
         result.ShouldNotHaveValidationErrorFor(r => r.From);
         result.ShouldNotHaveValidationErrorFor(r => r.From!.Email);
+    }
+
+    #endregion
+
+
+
+    #region ReplyTo
+
+    [Test]
+    public void Validation_ShouldNotFail_WhenReplyToIsNull()
+    {
+        var request = SendEmailRequest.Create();
+
+        var result = SendEmailRequestValidator.Instance.TestValidate(request);
+
+        result.ShouldNotHaveValidationErrorFor(r => r.ReplyTo);
+        result.ShouldNotHaveValidationErrorFor(r => r.ReplyTo!.Email);
+    }
+
+    [Test]
+    public void Validation_ShouldFail_WhenReplyToEmailIsInvalid()
+    {
+        var request = SendEmailRequest
+            .Create()
+            .ReplyTo(_invalidEmail);
+
+        var result = SendEmailRequestValidator.Instance.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(r => r.ReplyTo!.Email);
+    }
+
+    [Test]
+    public void Validation_ShouldNotFail_WhenReplyToEmailIsValid()
+    {
+        var request = SendEmailRequest
+            .Create()
+            .ReplyTo(_validEmail);
+
+        var result = SendEmailRequestValidator.Instance.TestValidate(request);
+
+        result.ShouldNotHaveValidationErrorFor(r => r.ReplyTo);
+        result.ShouldNotHaveValidationErrorFor(r => r.ReplyTo!.Email);
     }
 
     #endregion


### PR DESCRIPTION
## Motivation
Add `Reply To` field support for Send Email (transactional, bulk and testing) which were introduced recently in API.

## Description of Changes
- Added 'ReplyTo' field support to Send Email
- Updated models, request builder
- Added automated tests for aforementioned
- Updated example projects accordingly
- Updated documentation

Misc: Fixed Email feature folder name (and namespaces) in UnitTests project.

## Checklist
- [x] Acknowledged that contribution is made under the project's [LICENSE](https://github.com/mailtrap/mailtrap-dotnet/blob/main/LICENSE.md)
- [x] Confirmed that PR and code/documentation changes are following the [Contributor Code of Conduct](https://github.com/mailtrap/mailtrap-dotnet/blob/main/CODE_OF_CONDUCT.md)
- [x] PR is properly titled and contains the summary of changes introduced
- [x] PR branch is based on the latest main branch commit
- [x] PR contains some meaningful changes, including, but not limited to: functionality, tests, documentation, spelling, etc.
- [x] Added/updated XMLDoc and inline comments in the code, according to the changes made
- [x] Added/updated unit tests for added/changed functionality (if any)
- [x] Added/updated documentation files (if applicable)
