### PR TITLE
Cleanup copyright header from source files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -52,7 +52,8 @@ trim_trailing_whitespace = false
 [*.cs]
 
 # License header
-file_header_template = -----------------------------------------------------------------------\n<copyright file="{fileName}" company="Railsware Products Studio, LLC">\nCopyright (c) Railsware Products Studio, LLC. All rights reserved.\n</copyright>\n-----------------------------------------------------------------------
+file_header_template = unset
+# -----------------------------------------------------------------------\n<copyright file="{fileName}" company="Railsware Products Studio, LLC">\nCopyright (c) Railsware Products Studio, LLC. All rights reserved.\n</copyright>\n-----------------------------------------------------------------------
 
 # New line preferences
 csharp_new_line_before_open_brace = all

--- a/examples/Mailtrap.Example.Account/Account.cs
+++ b/examples/Mailtrap.Example.Account/Account.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Account.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using Mailtrap;
+﻿using Mailtrap;
 using Mailtrap.Accounts.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/examples/Mailtrap.Example.AccountAccess/AccountAccess.cs
+++ b/examples/Mailtrap.Example.AccountAccess/AccountAccess.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AccountAccess.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using Mailtrap;
+﻿using Mailtrap;
 using Mailtrap.AccountAccesses;
 using Mailtrap.AccountAccesses.Models;
 using Mailtrap.AccountAccesses.Requests;

--- a/examples/Mailtrap.Example.ApiUsage/GlobalUsings.cs
+++ b/examples/Mailtrap.Example.ApiUsage/GlobalUsings.cs
@@ -1,10 +1,3 @@
-// -----------------------------------------------------------------------
-// <copyright file="GlobalUsings.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
 global using System.Net.Mime;
 global using Mailtrap.AccountAccesses;
 global using Mailtrap.AccountAccesses.Models;

--- a/examples/Mailtrap.Example.ApiUsage/Logic/AccountAccessReactor.cs
+++ b/examples/Mailtrap.Example.ApiUsage/Logic/AccountAccessReactor.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AccountAccessReactor.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Example.ApiUsage.Logic;
+﻿namespace Mailtrap.Example.ApiUsage.Logic;
 
 
 internal sealed class AccountAccessReactor : Reactor

--- a/examples/Mailtrap.Example.ApiUsage/Logic/AccountReactor.cs
+++ b/examples/Mailtrap.Example.ApiUsage/Logic/AccountReactor.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AccountReactor.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Example.ApiUsage.Logic;
+﻿namespace Mailtrap.Example.ApiUsage.Logic;
 
 
 internal sealed class AccountReactor : Reactor

--- a/examples/Mailtrap.Example.ApiUsage/Logic/AttachmentReactor.cs
+++ b/examples/Mailtrap.Example.ApiUsage/Logic/AttachmentReactor.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AttachmentReactor.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Example.ApiUsage.Logic;
+﻿namespace Mailtrap.Example.ApiUsage.Logic;
 
 
 internal sealed class AttachmentReactor : Reactor

--- a/examples/Mailtrap.Example.ApiUsage/Logic/BillingReactor.cs
+++ b/examples/Mailtrap.Example.ApiUsage/Logic/BillingReactor.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="BillingReactor.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Example.ApiUsage.Logic;
+﻿namespace Mailtrap.Example.ApiUsage.Logic;
 
 
 internal sealed class BillingReactor : Reactor

--- a/examples/Mailtrap.Example.ApiUsage/Logic/InboxReactor.cs
+++ b/examples/Mailtrap.Example.ApiUsage/Logic/InboxReactor.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="InboxReactor.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Example.ApiUsage.Logic;
+﻿namespace Mailtrap.Example.ApiUsage.Logic;
 
 
 internal sealed class InboxReactor : Reactor

--- a/examples/Mailtrap.Example.ApiUsage/Logic/MessageReactor.cs
+++ b/examples/Mailtrap.Example.ApiUsage/Logic/MessageReactor.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="MessageReactor.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using Mailtrap.TestingMessages.Responses;
+﻿using Mailtrap.TestingMessages.Responses;
 
 
 namespace Mailtrap.Example.ApiUsage.Logic;

--- a/examples/Mailtrap.Example.ApiUsage/Logic/PermissionsReactor.cs
+++ b/examples/Mailtrap.Example.ApiUsage/Logic/PermissionsReactor.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="PermissionsReactor.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Example.ApiUsage.Logic;
+﻿namespace Mailtrap.Example.ApiUsage.Logic;
 
 
 internal sealed class PermissionsReactor : Reactor

--- a/examples/Mailtrap.Example.ApiUsage/Logic/ProjectReactor.cs
+++ b/examples/Mailtrap.Example.ApiUsage/Logic/ProjectReactor.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ProjectReactor.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Example.ApiUsage.Logic;
+﻿namespace Mailtrap.Example.ApiUsage.Logic;
 
 
 internal sealed class ProjectReactor : Reactor

--- a/examples/Mailtrap.Example.ApiUsage/Logic/Reactor.cs
+++ b/examples/Mailtrap.Example.ApiUsage/Logic/Reactor.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Reactor.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Example.ApiUsage.Logic;
+﻿namespace Mailtrap.Example.ApiUsage.Logic;
 
 
 internal abstract class Reactor

--- a/examples/Mailtrap.Example.ApiUsage/Logic/SendingDomainReactor.cs
+++ b/examples/Mailtrap.Example.ApiUsage/Logic/SendingDomainReactor.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendingDomainReactor.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Example.ApiUsage.Logic;
+﻿namespace Mailtrap.Example.ApiUsage.Logic;
 
 
 internal sealed class SendingDomainReactor : Reactor

--- a/examples/Mailtrap.Example.ApiUsage/Logic/TestSendReactor.cs
+++ b/examples/Mailtrap.Example.ApiUsage/Logic/TestSendReactor.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="TestSendReactor.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Example.ApiUsage.Logic;
+﻿namespace Mailtrap.Example.ApiUsage.Logic;
 
 
 internal sealed class TestSendReactor : Reactor

--- a/examples/Mailtrap.Example.ApiUsage/Logic/TestingMessageReactor.cs
+++ b/examples/Mailtrap.Example.ApiUsage/Logic/TestingMessageReactor.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="TestingMessageReactor.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using Mailtrap.TestingMessages.Responses;
+﻿using Mailtrap.TestingMessages.Responses;
 
 
 namespace Mailtrap.Example.ApiUsage.Logic;

--- a/examples/Mailtrap.Example.ApiUsage/Program.cs
+++ b/examples/Mailtrap.Example.ApiUsage/Program.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Program.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using Mailtrap;
+﻿using Mailtrap;
 
 
 HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder(args);

--- a/examples/Mailtrap.Example.Attachment/Attachment.cs
+++ b/examples/Mailtrap.Example.Attachment/Attachment.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Attachment.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using Mailtrap;
+﻿using Mailtrap;
 using Mailtrap.Attachments;
 using Mailtrap.Attachments.Models;
 using Mailtrap.Core.Models;

--- a/examples/Mailtrap.Example.Billing/Billing.cs
+++ b/examples/Mailtrap.Example.Billing/Billing.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Billing.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using Mailtrap;
+﻿using Mailtrap;
 using Mailtrap.Billing.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/examples/Mailtrap.Example.DependencyInjection/Program.cs
+++ b/examples/Mailtrap.Example.DependencyInjection/Program.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Program.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http.Headers;
 using Mailtrap;

--- a/examples/Mailtrap.Example.Email.Send/Program.cs
+++ b/examples/Mailtrap.Example.Email.Send/Program.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Program.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Net.Mime;
 using Mailtrap;
 using Mailtrap.Core.Models;

--- a/examples/Mailtrap.Example.Factory/Program.cs
+++ b/examples/Mailtrap.Example.Factory/Program.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Program.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http.Headers;
 using Mailtrap;

--- a/examples/Mailtrap.Example.Inbox/Inbox.cs
+++ b/examples/Mailtrap.Example.Inbox/Inbox.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Inbox.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using Mailtrap;
+﻿using Mailtrap;
 using Mailtrap.Accounts;
 using Mailtrap.Inboxes;
 using Mailtrap.Inboxes.Models;

--- a/examples/Mailtrap.Example.Permissions/Permissions.cs
+++ b/examples/Mailtrap.Example.Permissions/Permissions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Permissions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using Mailtrap;
+﻿using Mailtrap;
 using Mailtrap.Permissions.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/examples/Mailtrap.Example.Project/Project.cs
+++ b/examples/Mailtrap.Example.Project/Project.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Project.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using Mailtrap;
+﻿using Mailtrap;
 using Mailtrap.Accounts;
 using Mailtrap.Projects;
 using Mailtrap.Projects.Models;

--- a/examples/Mailtrap.Example.SendingDomain/SendingDomain.cs
+++ b/examples/Mailtrap.Example.SendingDomain/SendingDomain.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendingDomain.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using Mailtrap;
+﻿using Mailtrap;
 using Mailtrap.Accounts;
 using Mailtrap.SendingDomains;
 using Mailtrap.SendingDomains.Models;

--- a/examples/Mailtrap.Example.TestingMessage/TestingMessage.cs
+++ b/examples/Mailtrap.Example.TestingMessage/TestingMessage.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="TestingMessage.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using Mailtrap;
+﻿using Mailtrap;
 using Mailtrap.Inboxes;
 using Mailtrap.TestingMessages;
 using Mailtrap.TestingMessages.Models;

--- a/src/Mailtrap.Abstractions/AccountAccesses/IAccountAccessCollectionResource.cs
+++ b/src/Mailtrap.Abstractions/AccountAccesses/IAccountAccessCollectionResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IAccountAccessCollectionResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.AccountAccesses;
+﻿namespace Mailtrap.AccountAccesses;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/AccountAccesses/IAccountAccessResource.cs
+++ b/src/Mailtrap.Abstractions/AccountAccesses/IAccountAccessResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IAccountAccessResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.AccountAccesses;
+﻿namespace Mailtrap.AccountAccesses;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/AccountAccesses/Models/AccountAccess.cs
+++ b/src/Mailtrap.Abstractions/AccountAccesses/Models/AccountAccess.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AccountAccess.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.AccountAccesses.Models;
+﻿namespace Mailtrap.AccountAccesses.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/AccountAccesses/Models/AccountAccessFilter.cs
+++ b/src/Mailtrap.Abstractions/AccountAccesses/Models/AccountAccessFilter.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AccountAccessFilter.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.AccountAccesses.Models;
+﻿namespace Mailtrap.AccountAccesses.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/AccountAccesses/Models/AccountAccessPermissions.cs
+++ b/src/Mailtrap.Abstractions/AccountAccesses/Models/AccountAccessPermissions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AccountAccessPermissions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.AccountAccesses.Models;
+﻿namespace Mailtrap.AccountAccesses.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/AccountAccesses/Models/ResourceAccess.cs
+++ b/src/Mailtrap.Abstractions/AccountAccesses/Models/ResourceAccess.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ResourceAccess.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.AccountAccesses.Models;
+﻿namespace Mailtrap.AccountAccesses.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/AccountAccesses/Models/Specifier.cs
+++ b/src/Mailtrap.Abstractions/AccountAccesses/Models/Specifier.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Specifier.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.AccountAccesses.Models;
+﻿namespace Mailtrap.AccountAccesses.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/AccountAccesses/Models/SpecifierType.cs
+++ b/src/Mailtrap.Abstractions/AccountAccesses/Models/SpecifierType.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SpecifierType.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.AccountAccesses.Models;
+﻿namespace Mailtrap.AccountAccesses.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/AccountAccesses/Requests/UpdatePermissionsRequest.cs
+++ b/src/Mailtrap.Abstractions/AccountAccesses/Requests/UpdatePermissionsRequest.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UpdatePermissionsRequest.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.AccountAccesses.Requests;
+﻿namespace Mailtrap.AccountAccesses.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/AccountAccesses/Requests/UpdatePermissionsRequestItem.cs
+++ b/src/Mailtrap.Abstractions/AccountAccesses/Requests/UpdatePermissionsRequestItem.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UpdatePermissionsRequestItem.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.AccountAccesses.Requests;
+﻿namespace Mailtrap.AccountAccesses.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/AccountAccesses/Responses/DeleteAccountAccessResponse.cs
+++ b/src/Mailtrap.Abstractions/AccountAccesses/Responses/DeleteAccountAccessResponse.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="DeleteAccountAccessResponse.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.AccountAccesses.Responses;
+﻿namespace Mailtrap.AccountAccesses.Responses;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/AccountAccesses/Responses/UpdatePermissionsResponse.cs
+++ b/src/Mailtrap.Abstractions/AccountAccesses/Responses/UpdatePermissionsResponse.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UpdatePermissionsResponse.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.AccountAccesses.Responses;
+﻿namespace Mailtrap.AccountAccesses.Responses;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/AccountAccesses/Validators/UpdatePermissionsRequestItemValidator.cs
+++ b/src/Mailtrap.Abstractions/AccountAccesses/Validators/UpdatePermissionsRequestItemValidator.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UpdatePermissionsRequestItemValidator.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.AccountAccesses.Validators;
+﻿namespace Mailtrap.AccountAccesses.Validators;
 
 
 internal sealed class UpdatePermissionsRequestItemValidator : AbstractValidator<UpdatePermissionsRequestItem>

--- a/src/Mailtrap.Abstractions/AccountAccesses/Validators/UpdatePermissionsRequestValidator.cs
+++ b/src/Mailtrap.Abstractions/AccountAccesses/Validators/UpdatePermissionsRequestValidator.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UpdatePermissionsRequestValidator.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.AccountAccesses.Validators;
+﻿namespace Mailtrap.AccountAccesses.Validators;
 
 
 internal sealed class UpdatePermissionsRequestValidator : AbstractValidator<UpdatePermissionsRequest>

--- a/src/Mailtrap.Abstractions/Accounts/IAccountCollectionResource.cs
+++ b/src/Mailtrap.Abstractions/Accounts/IAccountCollectionResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IAccountCollectionResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Accounts;
+﻿namespace Mailtrap.Accounts;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Accounts/IAccountResource.cs
+++ b/src/Mailtrap.Abstractions/Accounts/IAccountResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IAccountResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Accounts;
+﻿namespace Mailtrap.Accounts;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Accounts/Models/Account.cs
+++ b/src/Mailtrap.Abstractions/Accounts/Models/Account.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Account.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Accounts.Models;
+﻿namespace Mailtrap.Accounts.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Attachments/IAttachmentCollectionResource.cs
+++ b/src/Mailtrap.Abstractions/Attachments/IAttachmentCollectionResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IAttachmentCollectionResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Attachments;
+﻿namespace Mailtrap.Attachments;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Attachments/IAttachmentResource.cs
+++ b/src/Mailtrap.Abstractions/Attachments/IAttachmentResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IAttachmentResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Attachments;
+﻿namespace Mailtrap.Attachments;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Attachments/Models/EmailAttachment.cs
+++ b/src/Mailtrap.Abstractions/Attachments/Models/EmailAttachment.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EmailAttachment.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Attachments.Models;
+﻿namespace Mailtrap.Attachments.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Attachments/Models/EmailAttachmentFilter.cs
+++ b/src/Mailtrap.Abstractions/Attachments/Models/EmailAttachmentFilter.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EmailAttachmentFilter.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Attachments.Models;
+﻿namespace Mailtrap.Attachments.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Billing/IBillingResource.cs
+++ b/src/Mailtrap.Abstractions/Billing/IBillingResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IBillingResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Billing;
+﻿namespace Mailtrap.Billing;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Billing/Models/BillingPlan.cs
+++ b/src/Mailtrap.Abstractions/Billing/Models/BillingPlan.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="BillingPlan.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Billing.Models;
+﻿namespace Mailtrap.Billing.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Billing/Models/BillingPlanUsage.cs
+++ b/src/Mailtrap.Abstractions/Billing/Models/BillingPlanUsage.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="BillingPlanUsage.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Billing.Models;
+﻿namespace Mailtrap.Billing.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Billing/Models/BillingPlanUsageMessageCounters.cs
+++ b/src/Mailtrap.Abstractions/Billing/Models/BillingPlanUsageMessageCounters.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="BillingPlanUsageMessageCounters.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Billing.Models;
+﻿namespace Mailtrap.Billing.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Billing/Models/BillingPlanUsageStatistics.cs
+++ b/src/Mailtrap.Abstractions/Billing/Models/BillingPlanUsageStatistics.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="BillingPlanUsageStatistics.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Billing.Models;
+﻿namespace Mailtrap.Billing.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Billing/Models/BillingUsage.cs
+++ b/src/Mailtrap.Abstractions/Billing/Models/BillingUsage.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="BillingUsage.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Billing.Models;
+﻿namespace Mailtrap.Billing.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Billing/Models/BillingUsagePeriod.cs
+++ b/src/Mailtrap.Abstractions/Billing/Models/BillingUsagePeriod.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="BillingUsagePeriod.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Billing.Models;
+﻿namespace Mailtrap.Billing.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Billing/Models/SendingBillingPlanUsageStatistics.cs
+++ b/src/Mailtrap.Abstractions/Billing/Models/SendingBillingPlanUsageStatistics.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendingBillingPlanUsageStatistics.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Billing.Models;
+﻿namespace Mailtrap.Billing.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Billing/Models/TestingBillingPlanUsageStatistics.cs
+++ b/src/Mailtrap.Abstractions/Billing/Models/TestingBillingPlanUsageStatistics.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="TestingBillingPlanUsageStatistics.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Billing.Models;
+﻿namespace Mailtrap.Billing.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Core/Exceptions/EmptyResponseException.cs
+++ b/src/Mailtrap.Abstractions/Core/Exceptions/EmptyResponseException.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EmptyResponseException.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Exceptions;
+﻿namespace Mailtrap.Core.Exceptions;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Core/Exceptions/HttpRequestFailedException.cs
+++ b/src/Mailtrap.Abstractions/Core/Exceptions/HttpRequestFailedException.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HttpRequestFailedException.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Exceptions;
+﻿namespace Mailtrap.Core.Exceptions;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Core/Exceptions/MailtrapApiException.cs
+++ b/src/Mailtrap.Abstractions/Core/Exceptions/MailtrapApiException.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="MailtrapApiException.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Exceptions;
+﻿namespace Mailtrap.Core.Exceptions;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Core/Exceptions/MailtrapException.cs
+++ b/src/Mailtrap.Abstractions/Core/Exceptions/MailtrapException.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="MailtrapException.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Exceptions;
+﻿namespace Mailtrap.Core.Exceptions;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Core/Exceptions/RequestValidationException.cs
+++ b/src/Mailtrap.Abstractions/Core/Exceptions/RequestValidationException.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="RequestValidationException.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Exceptions;
+﻿namespace Mailtrap.Core.Exceptions;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Core/Extensions/Ensure.cs
+++ b/src/Mailtrap.Abstractions/Core/Extensions/Ensure.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Ensure.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Extensions;
+﻿namespace Mailtrap.Core.Extensions;
 
 
 /// <exclude/>

--- a/src/Mailtrap.Abstractions/Core/Extensions/FluentValidationResultExtensions.cs
+++ b/src/Mailtrap.Abstractions/Core/Extensions/FluentValidationResultExtensions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="FluentValidationResultExtensions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using FluentValidationResult = FluentValidation.Results.ValidationResult;
+﻿using FluentValidationResult = FluentValidation.Results.ValidationResult;
 
 
 namespace Mailtrap.Core.Extensions;

--- a/src/Mailtrap.Abstractions/Core/Models/AccessLevel.cs
+++ b/src/Mailtrap.Abstractions/Core/Models/AccessLevel.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AccessLevel.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Models;
+﻿namespace Mailtrap.Core.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Core/Models/DispositionType.cs
+++ b/src/Mailtrap.Abstractions/Core/Models/DispositionType.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="DispositionType.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Models;
+﻿namespace Mailtrap.Core.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Core/Models/ResourceType.cs
+++ b/src/Mailtrap.Abstractions/Core/Models/ResourceType.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ResourceType.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Models;
+﻿namespace Mailtrap.Core.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Core/Models/StringEnum.cs
+++ b/src/Mailtrap.Abstractions/Core/Models/StringEnum.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="StringEnum.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 
 namespace Mailtrap.Core.Models;

--- a/src/Mailtrap.Abstractions/Core/Rest/IRestResource.cs
+++ b/src/Mailtrap.Abstractions/Core/Rest/IRestResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IRestResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Rest;
+﻿namespace Mailtrap.Core.Rest;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Core/Validation/IValidatable.cs
+++ b/src/Mailtrap.Abstractions/Core/Validation/IValidatable.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IValidatable.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Validation;
+﻿namespace Mailtrap.Core.Validation;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Core/Validation/ValidationResult.cs
+++ b/src/Mailtrap.Abstractions/Core/Validation/ValidationResult.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ValidationResult.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Validation;
+﻿namespace Mailtrap.Core.Validation;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Emails/IEmailClient.cs
+++ b/src/Mailtrap.Abstractions/Emails/IEmailClient.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IEmailClient.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Emails;
+﻿namespace Mailtrap.Emails;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Emails/Models/Attachment.cs
+++ b/src/Mailtrap.Abstractions/Emails/Models/Attachment.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Attachment.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Emails.Models;
+﻿namespace Mailtrap.Emails.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Emails/Models/EmailAddress.cs
+++ b/src/Mailtrap.Abstractions/Emails/Models/EmailAddress.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EmailAddress.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Emails.Models;
+﻿namespace Mailtrap.Emails.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Emails/Requests/SendEmailRequest.cs
+++ b/src/Mailtrap.Abstractions/Emails/Requests/SendEmailRequest.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequest.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Emails.Requests;
+﻿namespace Mailtrap.Emails.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Emails/Responses/SendEmailResponse.cs
+++ b/src/Mailtrap.Abstractions/Emails/Responses/SendEmailResponse.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailResponse.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Emails.Responses;
+﻿namespace Mailtrap.Emails.Responses;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Emails/Validators/AttachmentValidator.cs
+++ b/src/Mailtrap.Abstractions/Emails/Validators/AttachmentValidator.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AttachmentValidator.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Emails.Validators;
+﻿namespace Mailtrap.Emails.Validators;
 
 
 internal sealed class AttachmentValidator : AbstractValidator<Attachment>

--- a/src/Mailtrap.Abstractions/Emails/Validators/EmailAddressValidator.cs
+++ b/src/Mailtrap.Abstractions/Emails/Validators/EmailAddressValidator.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EmailAddressValidator.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Emails.Validators;
+﻿namespace Mailtrap.Emails.Validators;
 
 
 internal sealed class EmailAddressValidator : AbstractValidator<EmailAddress>

--- a/src/Mailtrap.Abstractions/Emails/Validators/SendEmailRequestValidator.cs
+++ b/src/Mailtrap.Abstractions/Emails/Validators/SendEmailRequestValidator.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestValidator.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Emails.Validators;
+﻿namespace Mailtrap.Emails.Validators;
 
 
 internal sealed class SendEmailRequestValidator : AbstractValidator<SendEmailRequest>

--- a/src/Mailtrap.Abstractions/GlobalUsings.cs
+++ b/src/Mailtrap.Abstractions/GlobalUsings.cs
@@ -1,10 +1,3 @@
-// -----------------------------------------------------------------------
-// <copyright file="GlobalUsings.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
 global using System.Collections.Concurrent;
 global using System.Diagnostics.CodeAnalysis;
 global using System.Net;

--- a/src/Mailtrap.Abstractions/IMailtrapClient.cs
+++ b/src/Mailtrap.Abstractions/IMailtrapClient.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IMailtrapClient.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap;
+﻿namespace Mailtrap;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/IMailtrapClientFactory.cs
+++ b/src/Mailtrap.Abstractions/IMailtrapClientFactory.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IMailtrapClientFactory.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap;
+﻿namespace Mailtrap;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Inboxes/IInboxCollectionResource.cs
+++ b/src/Mailtrap.Abstractions/Inboxes/IInboxCollectionResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IInboxCollectionResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Inboxes;
+﻿namespace Mailtrap.Inboxes;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Inboxes/IInboxResource.cs
+++ b/src/Mailtrap.Abstractions/Inboxes/IInboxResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IInboxResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Inboxes;
+﻿namespace Mailtrap.Inboxes;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Inboxes/Models/Inbox.cs
+++ b/src/Mailtrap.Abstractions/Inboxes/Models/Inbox.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Inbox.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Inboxes.Models;
+﻿namespace Mailtrap.Inboxes.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Inboxes/Models/InboxPermissions.cs
+++ b/src/Mailtrap.Abstractions/Inboxes/Models/InboxPermissions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="InboxPermissions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Inboxes.Models;
+﻿namespace Mailtrap.Inboxes.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Inboxes/Models/InboxStatus.cs
+++ b/src/Mailtrap.Abstractions/Inboxes/Models/InboxStatus.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="InboxStatus.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Inboxes.Models;
+﻿namespace Mailtrap.Inboxes.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Inboxes/Requests/CreateInboxRequest.cs
+++ b/src/Mailtrap.Abstractions/Inboxes/Requests/CreateInboxRequest.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="CreateInboxRequest.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Inboxes.Requests;
+﻿namespace Mailtrap.Inboxes.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Inboxes/Requests/InboxRequest.cs
+++ b/src/Mailtrap.Abstractions/Inboxes/Requests/InboxRequest.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="InboxRequest.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Inboxes.Requests;
+﻿namespace Mailtrap.Inboxes.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Inboxes/Requests/UpdateInboxRequest.cs
+++ b/src/Mailtrap.Abstractions/Inboxes/Requests/UpdateInboxRequest.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UpdateInboxRequest.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Inboxes.Requests;
+﻿namespace Mailtrap.Inboxes.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Permissions/IPermissionsResource.cs
+++ b/src/Mailtrap.Abstractions/Permissions/IPermissionsResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IPermissionsResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Permissions;
+﻿namespace Mailtrap.Permissions;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Permissions/Models/ResourcePermissions.cs
+++ b/src/Mailtrap.Abstractions/Permissions/Models/ResourcePermissions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ResourcePermissions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Permissions.Models;
+﻿namespace Mailtrap.Permissions.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Projects/IProjectCollectionResource.cs
+++ b/src/Mailtrap.Abstractions/Projects/IProjectCollectionResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IProjectCollectionResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Projects;
+﻿namespace Mailtrap.Projects;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Projects/IProjectResource.cs
+++ b/src/Mailtrap.Abstractions/Projects/IProjectResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IProjectResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Projects;
+﻿namespace Mailtrap.Projects;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Projects/Models/Project.cs
+++ b/src/Mailtrap.Abstractions/Projects/Models/Project.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Project.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Projects.Models;
+﻿namespace Mailtrap.Projects.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Projects/Models/ProjectPermissions.cs
+++ b/src/Mailtrap.Abstractions/Projects/Models/ProjectPermissions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ProjectPermissions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Projects.Models;
+﻿namespace Mailtrap.Projects.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Projects/Models/ProjectShareLinks.cs
+++ b/src/Mailtrap.Abstractions/Projects/Models/ProjectShareLinks.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ProjectShareLinks.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Projects.Models;
+﻿namespace Mailtrap.Projects.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Projects/Requests/CreateProjectRequest.cs
+++ b/src/Mailtrap.Abstractions/Projects/Requests/CreateProjectRequest.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="CreateProjectRequest.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Projects.Requests;
+﻿namespace Mailtrap.Projects.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Projects/Requests/ProjectRequest.cs
+++ b/src/Mailtrap.Abstractions/Projects/Requests/ProjectRequest.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ProjectRequest.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Projects.Requests;
+﻿namespace Mailtrap.Projects.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Projects/Requests/UpdateProjectRequest.cs
+++ b/src/Mailtrap.Abstractions/Projects/Requests/UpdateProjectRequest.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UpdateProjectRequest.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Projects.Requests;
+﻿namespace Mailtrap.Projects.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Projects/Responses/DeleteProjectResponse.cs
+++ b/src/Mailtrap.Abstractions/Projects/Responses/DeleteProjectResponse.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="DeleteProjectResponse.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Projects.Responses;
+﻿namespace Mailtrap.Projects.Responses;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/Projects/Validators/ProjectRequestValidator.cs
+++ b/src/Mailtrap.Abstractions/Projects/Validators/ProjectRequestValidator.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ProjectRequestValidator.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Projects.Validators;
+﻿namespace Mailtrap.Projects.Validators;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/SendingDomains/ISendingDomainCollectionResource.cs
+++ b/src/Mailtrap.Abstractions/SendingDomains/ISendingDomainCollectionResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ISendingDomainCollectionResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.SendingDomains;
+﻿namespace Mailtrap.SendingDomains;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/SendingDomains/ISendingDomainResource.cs
+++ b/src/Mailtrap.Abstractions/SendingDomains/ISendingDomainResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ISendingDomainResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.SendingDomains;
+﻿namespace Mailtrap.SendingDomains;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/SendingDomains/Models/SendingDomain.cs
+++ b/src/Mailtrap.Abstractions/SendingDomains/Models/SendingDomain.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendingDomain.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.SendingDomains.Models;
+﻿namespace Mailtrap.SendingDomains.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/SendingDomains/Models/SendingDomainComplianceStatus.cs
+++ b/src/Mailtrap.Abstractions/SendingDomains/Models/SendingDomainComplianceStatus.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendingDomainComplianceStatus.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.SendingDomains.Models;
+﻿namespace Mailtrap.SendingDomains.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/SendingDomains/Models/SendingDomainDnsRecord.cs
+++ b/src/Mailtrap.Abstractions/SendingDomains/Models/SendingDomainDnsRecord.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendingDomainDnsRecord.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.SendingDomains.Models;
+﻿namespace Mailtrap.SendingDomains.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/SendingDomains/Models/SendingDomainDnsRecordStatus.cs
+++ b/src/Mailtrap.Abstractions/SendingDomains/Models/SendingDomainDnsRecordStatus.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendingDomainDnsRecordStatus.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.SendingDomains.Models;
+﻿namespace Mailtrap.SendingDomains.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/SendingDomains/Models/SendingDomainPermissions.cs
+++ b/src/Mailtrap.Abstractions/SendingDomains/Models/SendingDomainPermissions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendingDomainPermissions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.SendingDomains.Models;
+﻿namespace Mailtrap.SendingDomains.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/SendingDomains/Requests/CreateSendingDomainRequest.cs
+++ b/src/Mailtrap.Abstractions/SendingDomains/Requests/CreateSendingDomainRequest.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="CreateSendingDomainRequest.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.SendingDomains.Requests;
+﻿namespace Mailtrap.SendingDomains.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/SendingDomains/Requests/SendingDomainInstructionsRequest.cs
+++ b/src/Mailtrap.Abstractions/SendingDomains/Requests/SendingDomainInstructionsRequest.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendingDomainInstructionsRequest.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.SendingDomains.Requests;
+﻿namespace Mailtrap.SendingDomains.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/SendingDomains/Validators/SendingDomainInstructionsRequestValidator.cs
+++ b/src/Mailtrap.Abstractions/SendingDomains/Validators/SendingDomainInstructionsRequestValidator.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendingDomainInstructionsRequestValidator.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.SendingDomains.Validators;
+﻿namespace Mailtrap.SendingDomains.Validators;
 
 
 internal sealed class SendingDomainInstructionsRequestValidator : AbstractValidator<SendingDomainInstructionsRequest>

--- a/src/Mailtrap.Abstractions/TestingMessages/Converters/BlacklistReportJsonConverter.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Converters/BlacklistReportJsonConverter.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="BlacklistReportJsonConverter.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Converters;
+﻿namespace Mailtrap.TestingMessages.Converters;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/ITestingMessageCollectionResource.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/ITestingMessageCollectionResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ITestingMessageCollectionResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages;
+﻿namespace Mailtrap.TestingMessages;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/ITestingMessageResource.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/ITestingMessageResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ITestingMessageResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages;
+﻿namespace Mailtrap.TestingMessages;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Models/BlacklistReport.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Models/BlacklistReport.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="BlacklistReport.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Models;
+﻿namespace Mailtrap.TestingMessages.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Models/BlacklistReportItem.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Models/BlacklistReportItem.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="BlacklistReportItem.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Models;
+﻿namespace Mailtrap.TestingMessages.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Models/BlacklistReportResult.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Models/BlacklistReportResult.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="BlacklistReportResult.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Models;
+﻿namespace Mailtrap.TestingMessages.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Models/EmailClients.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Models/EmailClients.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EmailClients.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Models;
+﻿namespace Mailtrap.TestingMessages.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Models/HtmlAnalysisError.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Models/HtmlAnalysisError.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HtmlAnalysisError.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Models;
+﻿namespace Mailtrap.TestingMessages.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Models/HtmlAnalysisReport.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Models/HtmlAnalysisReport.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HtmlAnalysisReport.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Models;
+﻿namespace Mailtrap.TestingMessages.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Models/SmtpDetails.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Models/SmtpDetails.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SmtpDetails.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Models;
+﻿namespace Mailtrap.TestingMessages.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Models/SmtpInformation.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Models/SmtpInformation.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SmtpInformation.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Models;
+﻿namespace Mailtrap.TestingMessages.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Models/SpamReport.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Models/SpamReport.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SpamReport.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Models;
+﻿namespace Mailtrap.TestingMessages.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Models/SpamReportItem.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Models/SpamReportItem.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SpamReportItem.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Models;
+﻿namespace Mailtrap.TestingMessages.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Models/TestingMessage.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Models/TestingMessage.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="TestingMessage.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Models;
+﻿namespace Mailtrap.TestingMessages.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Models/TestingMessageFilter.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Models/TestingMessageFilter.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="TestingMessageFilter.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Models;
+﻿namespace Mailtrap.TestingMessages.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Models/TestingMessageHeaders.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Models/TestingMessageHeaders.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="TestingMessageHeaders.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Models;
+﻿namespace Mailtrap.TestingMessages.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Models/TestingMessageHtmlReport.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Models/TestingMessageHtmlReport.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="TestingMessageHtmlReport.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Models;
+﻿namespace Mailtrap.TestingMessages.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Models/TestingMessageSpamReport.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Models/TestingMessageSpamReport.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="TestingMessageSpamReport.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Models;
+﻿namespace Mailtrap.TestingMessages.Models;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Requests/ForwardTestingMessageRequest.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Requests/ForwardTestingMessageRequest.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ForwardTestingMessageRequest.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Requests;
+﻿namespace Mailtrap.TestingMessages.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Requests/UpdateTestingMessageRequest.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Requests/UpdateTestingMessageRequest.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UpdateTestingMessageRequest.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Requests;
+﻿namespace Mailtrap.TestingMessages.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Responses/ForwardTestingMessageResponse.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Responses/ForwardTestingMessageResponse.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ForwardTestingMessageResponse.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Responses;
+﻿namespace Mailtrap.TestingMessages.Responses;
 
 
 /// <summary>

--- a/src/Mailtrap.Abstractions/TestingMessages/Validators/ForwardTestingMessageRequestValidator.cs
+++ b/src/Mailtrap.Abstractions/TestingMessages/Validators/ForwardTestingMessageRequestValidator.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ForwardTestingMessageRequestValidator.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Validators;
+﻿namespace Mailtrap.TestingMessages.Validators;
 
 
 internal sealed class ForwardTestingMessageRequestValidator : AbstractValidator<ForwardTestingMessageRequest>

--- a/src/Mailtrap/AccountAccesses/AccountAccessCollectionResource.cs
+++ b/src/Mailtrap/AccountAccesses/AccountAccessCollectionResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AccountAccessCollectionResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.AccountAccesses;
+﻿namespace Mailtrap.AccountAccesses;
 
 
 internal sealed class AccountAccessCollectionResource : RestResource, IAccountAccessCollectionResource

--- a/src/Mailtrap/AccountAccesses/AccountAccessResource.cs
+++ b/src/Mailtrap/AccountAccesses/AccountAccessResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AccountAccessResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.AccountAccesses;
+﻿namespace Mailtrap.AccountAccesses;
 
 
 internal sealed class AccountAccessResource : RestResource, IAccountAccessResource

--- a/src/Mailtrap/Accounts/AccountCollectionResource.cs
+++ b/src/Mailtrap/Accounts/AccountCollectionResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AccountCollectionResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Accounts;
+﻿namespace Mailtrap.Accounts;
 
 
 internal sealed class AccountCollectionResource : RestResource, IAccountCollectionResource

--- a/src/Mailtrap/Accounts/AccountResource.cs
+++ b/src/Mailtrap/Accounts/AccountResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AccountResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using AccountAccessResource = Mailtrap.AccountAccesses.AccountAccessResource;
+﻿using AccountAccessResource = Mailtrap.AccountAccesses.AccountAccessResource;
 
 
 namespace Mailtrap.Accounts;

--- a/src/Mailtrap/Attachments/AttachmentCollectionResource.cs
+++ b/src/Mailtrap/Attachments/AttachmentCollectionResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AttachmentCollectionResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Attachments;
+﻿namespace Mailtrap.Attachments;
 
 
 internal sealed class AttachmentCollectionResource : RestResource, IAttachmentCollectionResource

--- a/src/Mailtrap/Attachments/AttachmentResource.cs
+++ b/src/Mailtrap/Attachments/AttachmentResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AttachmentResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Attachments;
+﻿namespace Mailtrap.Attachments;
 
 
 internal sealed class AttachmentResource : RestResource, IAttachmentResource

--- a/src/Mailtrap/Billing/BillingResource.cs
+++ b/src/Mailtrap/Billing/BillingResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="BillingResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Billing;
+﻿namespace Mailtrap.Billing;
 
 
 internal sealed class BillingResource : RestResource, IBillingResource

--- a/src/Mailtrap/Configuration/MailtrapClientOptions.cs
+++ b/src/Mailtrap/Configuration/MailtrapClientOptions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="MailtrapClientOptions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Configuration;
+﻿namespace Mailtrap.Configuration;
 
 
 /// <summary>

--- a/src/Mailtrap/Configuration/MailtrapClientOptionsValidator.cs
+++ b/src/Mailtrap/Configuration/MailtrapClientOptionsValidator.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="MailtrapClientOptionsValidator.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Configuration;
+﻿namespace Mailtrap.Configuration;
 
 
 internal sealed class MailtrapClientOptionsValidator : AbstractValidator<MailtrapClientOptions>

--- a/src/Mailtrap/Configuration/MailtrapJsonSerializerOptions.cs
+++ b/src/Mailtrap/Configuration/MailtrapJsonSerializerOptions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="MailtrapJsonSerializerOptions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Configuration;
+﻿namespace Mailtrap.Configuration;
 
 
 internal static class MailtrapJsonSerializerOptions

--- a/src/Mailtrap/Core/Constants/Client.cs
+++ b/src/Mailtrap/Core/Constants/Client.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Client.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Constants;
+﻿namespace Mailtrap.Core.Constants;
 
 
 internal static class Client

--- a/src/Mailtrap/Core/Constants/Endpoints.cs
+++ b/src/Mailtrap/Core/Constants/Endpoints.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Endpoints.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Constants;
+﻿namespace Mailtrap.Core.Constants;
 
 
 /// <summary>

--- a/src/Mailtrap/Core/Constants/HeaderValues.cs
+++ b/src/Mailtrap/Core/Constants/HeaderValues.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HeaderValues.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Constants;
+﻿namespace Mailtrap.Core.Constants;
 
 
 /// <summary>

--- a/src/Mailtrap/Core/Constants/MimeTypes.cs
+++ b/src/Mailtrap/Core/Constants/MimeTypes.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="MimeTypes.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Constants;
+﻿namespace Mailtrap.Core.Constants;
 
 
 internal static class MimeTypes

--- a/src/Mailtrap/Core/Constants/UrlSegments.cs
+++ b/src/Mailtrap/Core/Constants/UrlSegments.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UrlSegments.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Constants;
+﻿namespace Mailtrap.Core.Constants;
 
 
 internal static class UrlSegments

--- a/src/Mailtrap/Core/Converters/StringEnumJsonConverter.cs
+++ b/src/Mailtrap/Core/Converters/StringEnumJsonConverter.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="StringEnumJsonConverter.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Converters;
+﻿namespace Mailtrap.Core.Converters;
 
 
 /// <summary>

--- a/src/Mailtrap/Core/Converters/StringEnumJsonConverterFactory.cs
+++ b/src/Mailtrap/Core/Converters/StringEnumJsonConverterFactory.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="StringEnumJsonConverterFactory.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Converters;
+﻿namespace Mailtrap.Core.Converters;
 
 
 /// <summary>

--- a/src/Mailtrap/Core/Extensions/CollectionExtensions.cs
+++ b/src/Mailtrap/Core/Extensions/CollectionExtensions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="CollectionExtensions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Extensions;
+﻿namespace Mailtrap.Core.Extensions;
 
 
 /// <summary>

--- a/src/Mailtrap/Core/Extensions/HttpContentExtensions.cs
+++ b/src/Mailtrap/Core/Extensions/HttpContentExtensions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HttpContentExtensions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Extensions;
+﻿namespace Mailtrap.Core.Extensions;
 
 
 /// <summary>

--- a/src/Mailtrap/Core/Extensions/HttpMethodEx.cs
+++ b/src/Mailtrap/Core/Extensions/HttpMethodEx.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HttpMethodEx.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Extensions;
+﻿namespace Mailtrap.Core.Extensions;
 
 
 /// <summary>

--- a/src/Mailtrap/Core/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/Mailtrap/Core/Extensions/HttpRequestMessageExtensions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HttpRequestMessageExtensions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Extensions;
+﻿namespace Mailtrap.Core.Extensions;
 
 
 /// <summary>

--- a/src/Mailtrap/Core/Extensions/UriExtensions.cs
+++ b/src/Mailtrap/Core/Extensions/UriExtensions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UriExtensions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Extensions;
+﻿namespace Mailtrap.Core.Extensions;
 
 
 /// <summary>

--- a/src/Mailtrap/Core/Http/FactoryHttpClientProvider.cs
+++ b/src/Mailtrap/Core/Http/FactoryHttpClientProvider.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="FactoryHttpClientProvider.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Http;
+﻿namespace Mailtrap.Core.Http;
 
 
 /// <summary>

--- a/src/Mailtrap/Core/Http/HttpRequestContentFactory.cs
+++ b/src/Mailtrap/Core/Http/HttpRequestContentFactory.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HttpRequestContentFactory.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Http;
+﻿namespace Mailtrap.Core.Http;
 
 
 /// <summary>

--- a/src/Mailtrap/Core/Http/HttpRequestMessageFactory.cs
+++ b/src/Mailtrap/Core/Http/HttpRequestMessageFactory.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HttpRequestMessageFactory.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Http;
+﻿namespace Mailtrap.Core.Http;
 
 
 /// <summary>

--- a/src/Mailtrap/Core/Http/HttpResponseHandlerFactory.cs
+++ b/src/Mailtrap/Core/Http/HttpResponseHandlerFactory.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HttpResponseHandlerFactory.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Http;
+﻿namespace Mailtrap.Core.Http;
 
 
 internal sealed class HttpResponseHandlerFactory : IHttpResponseHandlerFactory

--- a/src/Mailtrap/Core/Http/IHttpClientProvider.cs
+++ b/src/Mailtrap/Core/Http/IHttpClientProvider.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IHttpClientProvider.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Http;
+﻿namespace Mailtrap.Core.Http;
 
 
 internal interface IHttpClientProvider

--- a/src/Mailtrap/Core/Http/IHttpRequestContentFactory.cs
+++ b/src/Mailtrap/Core/Http/IHttpRequestContentFactory.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IHttpRequestContentFactory.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Http;
+﻿namespace Mailtrap.Core.Http;
 
 
 /// <summary>

--- a/src/Mailtrap/Core/Http/IHttpRequestMessageFactory.cs
+++ b/src/Mailtrap/Core/Http/IHttpRequestMessageFactory.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IHttpRequestMessageFactory.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Http;
+﻿namespace Mailtrap.Core.Http;
 
 
 /// <summary>

--- a/src/Mailtrap/Core/Http/IHttpResponseHandlerFactory.cs
+++ b/src/Mailtrap/Core/Http/IHttpResponseHandlerFactory.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IHttpResponseHandlerFactory.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Http;
+﻿namespace Mailtrap.Core.Http;
 
 
 internal interface IHttpResponseHandlerFactory

--- a/src/Mailtrap/Core/Http/ResponseHandlers/HttpResponseHandler.cs
+++ b/src/Mailtrap/Core/Http/ResponseHandlers/HttpResponseHandler.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HttpResponseHandler.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Http.ResponseHandlers;
+﻿namespace Mailtrap.Core.Http.ResponseHandlers;
 
 
 internal abstract class HttpResponseHandler<T> : IHttpResponseHandler<T>

--- a/src/Mailtrap/Core/Http/ResponseHandlers/IHttpResponseHandler.cs
+++ b/src/Mailtrap/Core/Http/ResponseHandlers/IHttpResponseHandler.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IHttpResponseHandler.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Http.ResponseHandlers;
+﻿namespace Mailtrap.Core.Http.ResponseHandlers;
 
 
 internal interface IHttpResponseHandler<T>

--- a/src/Mailtrap/Core/Http/ResponseHandlers/JsonContentHttpResponseHandler.cs
+++ b/src/Mailtrap/Core/Http/ResponseHandlers/JsonContentHttpResponseHandler.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="JsonContentHttpResponseHandler.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Http.ResponseHandlers;
+﻿namespace Mailtrap.Core.Http.ResponseHandlers;
 
 
 internal sealed class JsonContentHttpResponseHandler<T> : HttpResponseHandler<T>

--- a/src/Mailtrap/Core/Http/ResponseHandlers/PlainTextContentHttpResponseHandler.cs
+++ b/src/Mailtrap/Core/Http/ResponseHandlers/PlainTextContentHttpResponseHandler.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="PlainTextContentHttpResponseHandler.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Http.ResponseHandlers;
+﻿namespace Mailtrap.Core.Http.ResponseHandlers;
 
 
 internal sealed class PlainTextContentHttpResponseHandler : HttpResponseHandler<string>

--- a/src/Mailtrap/Core/Http/ResponseHandlers/StatusCodeHttpResponseHandler.cs
+++ b/src/Mailtrap/Core/Http/ResponseHandlers/StatusCodeHttpResponseHandler.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="StatusCodeHttpResponseHandler.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Http.ResponseHandlers;
+﻿namespace Mailtrap.Core.Http.ResponseHandlers;
 
 
 internal sealed class StatusCodeHttpResponseHandler : HttpResponseHandler<HttpStatusCode>

--- a/src/Mailtrap/Core/Http/StaticHttpClientProvider.cs
+++ b/src/Mailtrap/Core/Http/StaticHttpClientProvider.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="StaticHttpClientProvider.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Http;
+﻿namespace Mailtrap.Core.Http;
 
 
 /// <summary>

--- a/src/Mailtrap/Core/Models/Problem.cs
+++ b/src/Mailtrap/Core/Models/Problem.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="Problem.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Models;
+﻿namespace Mailtrap.Core.Models;
 
 
 internal sealed record Problem

--- a/src/Mailtrap/Core/Rest/Commands/DeleteRestResourceCommand.cs
+++ b/src/Mailtrap/Core/Rest/Commands/DeleteRestResourceCommand.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="DeleteRestResourceCommand.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Rest.Commands;
+﻿namespace Mailtrap.Core.Rest.Commands;
 
 
 internal sealed class DeleteRestResourceCommand<TResponse> : RestResourceCommand<TResponse>

--- a/src/Mailtrap/Core/Rest/Commands/GetRestResourceCommand.cs
+++ b/src/Mailtrap/Core/Rest/Commands/GetRestResourceCommand.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="GetRestResourceCommand.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Rest.Commands;
+﻿namespace Mailtrap.Core.Rest.Commands;
 
 
 internal class GetRestResourceCommand<TResponse> : RestResourceCommand<TResponse>

--- a/src/Mailtrap/Core/Rest/Commands/GetWithPlainTextResultRestResourceCommand.cs
+++ b/src/Mailtrap/Core/Rest/Commands/GetWithPlainTextResultRestResourceCommand.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="GetWithPlainTextResultRestResourceCommand.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Rest.Commands;
+﻿namespace Mailtrap.Core.Rest.Commands;
 
 
 internal sealed class GetWithPlainTextResultRestResourceCommand : GetRestResourceCommand<string>

--- a/src/Mailtrap/Core/Rest/Commands/IRestResourceCommand.cs
+++ b/src/Mailtrap/Core/Rest/Commands/IRestResourceCommand.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IRestResourceCommand.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Rest.Commands;
+﻿namespace Mailtrap.Core.Rest.Commands;
 
 
 internal interface IRestResourceCommand<TResponse>

--- a/src/Mailtrap/Core/Rest/Commands/PatchRestResourceCommand.cs
+++ b/src/Mailtrap/Core/Rest/Commands/PatchRestResourceCommand.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="PatchRestResourceCommand.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Rest.Commands;
+﻿namespace Mailtrap.Core.Rest.Commands;
 
 
 internal sealed class PatchRestResourceCommand<TResponse> : RestResourceCommand<TResponse>

--- a/src/Mailtrap/Core/Rest/Commands/PatchWithContentRestResourceCommand.cs
+++ b/src/Mailtrap/Core/Rest/Commands/PatchWithContentRestResourceCommand.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="PatchWithContentRestResourceCommand.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Rest.Commands;
+﻿namespace Mailtrap.Core.Rest.Commands;
 
 
 internal sealed class PatchWithContentRestResourceCommand<TRequest, TResponse>

--- a/src/Mailtrap/Core/Rest/Commands/PostRestResourceCommand.cs
+++ b/src/Mailtrap/Core/Rest/Commands/PostRestResourceCommand.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="PostRestResourceCommand.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Rest.Commands;
+﻿namespace Mailtrap.Core.Rest.Commands;
 
 
 internal class PostRestResourceCommand<TRequest, TResponse>

--- a/src/Mailtrap/Core/Rest/Commands/PostWithStatusCodeResultRestResourceCommand.cs
+++ b/src/Mailtrap/Core/Rest/Commands/PostWithStatusCodeResultRestResourceCommand.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="PostWithStatusCodeResultRestResourceCommand.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Rest.Commands;
+﻿namespace Mailtrap.Core.Rest.Commands;
 
 
 internal sealed class PostWithStatusCodeResultRestResourceCommand<TRequest>

--- a/src/Mailtrap/Core/Rest/Commands/PutRestResourceCommand.cs
+++ b/src/Mailtrap/Core/Rest/Commands/PutRestResourceCommand.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="PutRestResourceCommand.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Rest.Commands;
+﻿namespace Mailtrap.Core.Rest.Commands;
 
 
 internal sealed class PutRestResourceCommand<TRequest, TResponse>

--- a/src/Mailtrap/Core/Rest/Commands/RestResourceCommand.cs
+++ b/src/Mailtrap/Core/Rest/Commands/RestResourceCommand.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="RestResourceCommand.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Rest.Commands;
+﻿namespace Mailtrap.Core.Rest.Commands;
 
 
 internal abstract class RestResourceCommand<TResponse> : IRestResourceCommand<TResponse>

--- a/src/Mailtrap/Core/Rest/Commands/RestResourceCommandWithRequest.cs
+++ b/src/Mailtrap/Core/Rest/Commands/RestResourceCommandWithRequest.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="RestResourceCommandWithRequest.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Rest.Commands;
+﻿namespace Mailtrap.Core.Rest.Commands;
 
 
 internal abstract class RestResourceCommandWithRequest<TRequest, TResponse>

--- a/src/Mailtrap/Core/Rest/IRestResourceCommandFactory.cs
+++ b/src/Mailtrap/Core/Rest/IRestResourceCommandFactory.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IRestResourceCommandFactory.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Rest;
+﻿namespace Mailtrap.Core.Rest;
 
 
 internal interface IRestResourceCommandFactory

--- a/src/Mailtrap/Core/Rest/RestResource.cs
+++ b/src/Mailtrap/Core/Rest/RestResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="RestResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Rest;
+﻿namespace Mailtrap.Core.Rest;
 
 
 /// <summary>

--- a/src/Mailtrap/Core/Rest/RestResourceCommandFactory.cs
+++ b/src/Mailtrap/Core/Rest/RestResourceCommandFactory.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="RestResourceCommandFactory.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Core.Rest;
+﻿namespace Mailtrap.Core.Rest;
 
 
 internal sealed class RestResourceCommandFactory : IRestResourceCommandFactory

--- a/src/Mailtrap/Emails/EmailClient.cs
+++ b/src/Mailtrap/Emails/EmailClient.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EmailClient.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Emails;
+﻿namespace Mailtrap.Emails;
 
 
 /// <summary>

--- a/src/Mailtrap/Emails/EmailClientEndpointProvider.cs
+++ b/src/Mailtrap/Emails/EmailClientEndpointProvider.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EmailClientEndpointProvider.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Emails;
+﻿namespace Mailtrap.Emails;
 
 
 /// <summary>

--- a/src/Mailtrap/Emails/EmailClientFactory.cs
+++ b/src/Mailtrap/Emails/EmailClientFactory.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EmailClientFactory.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Emails;
+﻿namespace Mailtrap.Emails;
 
 
 /// <summary>

--- a/src/Mailtrap/Emails/IEmailClientEndpointProvider.cs
+++ b/src/Mailtrap/Emails/IEmailClientEndpointProvider.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IEmailClientEndpointProvider.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Emails;
+﻿namespace Mailtrap.Emails;
 
 
 /// <summary>

--- a/src/Mailtrap/Emails/IEmailClientFactory.cs
+++ b/src/Mailtrap/Emails/IEmailClientFactory.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="IEmailClientFactory.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Emails;
+﻿namespace Mailtrap.Emails;
 
 
 /// <summary>

--- a/src/Mailtrap/Emails/Requests/SendEmailRequestBuilder.cs
+++ b/src/Mailtrap/Emails/Requests/SendEmailRequestBuilder.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilder.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Emails.Requests;
+﻿namespace Mailtrap.Emails.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap/GlobalUsings.cs
+++ b/src/Mailtrap/GlobalUsings.cs
@@ -1,10 +1,3 @@
-// -----------------------------------------------------------------------
-// <copyright file="GlobalUsings.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
 global using System.Globalization;
 global using System.Net;
 global using System.Net.Http.Headers;

--- a/src/Mailtrap/Inboxes/InboxCollectionResource.cs
+++ b/src/Mailtrap/Inboxes/InboxCollectionResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="InboxCollectionResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Inboxes;
+﻿namespace Mailtrap.Inboxes;
 
 
 internal sealed class InboxCollectionResource : RestResource, IInboxCollectionResource

--- a/src/Mailtrap/Inboxes/InboxResource.cs
+++ b/src/Mailtrap/Inboxes/InboxResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="InboxResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Inboxes;
+﻿namespace Mailtrap.Inboxes;
 
 
 internal sealed class InboxResource : RestResource, IInboxResource

--- a/src/Mailtrap/Inboxes/Requests/CreateInboxRequestDto.cs
+++ b/src/Mailtrap/Inboxes/Requests/CreateInboxRequestDto.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="CreateInboxRequestDto.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Inboxes.Requests;
+﻿namespace Mailtrap.Inboxes.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap/Inboxes/Requests/InboxRequestDto.cs
+++ b/src/Mailtrap/Inboxes/Requests/InboxRequestDto.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="InboxRequestDto.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Inboxes.Requests;
+﻿namespace Mailtrap.Inboxes.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap/Inboxes/Requests/InboxRequestExtensions.cs
+++ b/src/Mailtrap/Inboxes/Requests/InboxRequestExtensions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="InboxRequestExtensions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Inboxes.Requests;
+﻿namespace Mailtrap.Inboxes.Requests;
 
 
 internal static class InboxRequestExtensions

--- a/src/Mailtrap/Inboxes/Requests/UpdateInboxRequestDto.cs
+++ b/src/Mailtrap/Inboxes/Requests/UpdateInboxRequestDto.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UpdateInboxRequestDto.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Inboxes.Requests;
+﻿namespace Mailtrap.Inboxes.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap/MailtrapClient.cs
+++ b/src/Mailtrap/MailtrapClient.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="MailtrapClient.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap;
+﻿namespace Mailtrap;
 
 
 /// <summary>

--- a/src/Mailtrap/MailtrapClientFactory.cs
+++ b/src/Mailtrap/MailtrapClientFactory.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="MailtrapClientFactory.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap;
+﻿namespace Mailtrap;
 
 
 /// <summary>

--- a/src/Mailtrap/MailtrapClientServiceCollectionExtensions.cs
+++ b/src/Mailtrap/MailtrapClientServiceCollectionExtensions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="MailtrapClientServiceCollectionExtensions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap;
+﻿namespace Mailtrap;
 
 
 /// <summary>

--- a/src/Mailtrap/Permissions/PermissionsResource.cs
+++ b/src/Mailtrap/Permissions/PermissionsResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="PermissionsResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Permissions;
+﻿namespace Mailtrap.Permissions;
 
 
 internal sealed class PermissionsResource : RestResource, IPermissionsResource

--- a/src/Mailtrap/Projects/ProjectCollectionResource.cs
+++ b/src/Mailtrap/Projects/ProjectCollectionResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ProjectCollectionResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Projects;
+﻿namespace Mailtrap.Projects;
 
 
 internal sealed class ProjectCollectionResource : RestResource, IProjectCollectionResource

--- a/src/Mailtrap/Projects/ProjectResource.cs
+++ b/src/Mailtrap/Projects/ProjectResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ProjectResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Projects;
+﻿namespace Mailtrap.Projects;
 
 
 internal sealed class ProjectResource : RestResource, IProjectResource

--- a/src/Mailtrap/Projects/Requests/CreateProjectRequestDto.cs
+++ b/src/Mailtrap/Projects/Requests/CreateProjectRequestDto.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="CreateProjectRequestDto.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Projects.Requests;
+﻿namespace Mailtrap.Projects.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap/Projects/Requests/ProjectRequestDto.cs
+++ b/src/Mailtrap/Projects/Requests/ProjectRequestDto.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ProjectRequestDto.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Projects.Requests;
+﻿namespace Mailtrap.Projects.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap/Projects/Requests/ProjectRequestExtensions.cs
+++ b/src/Mailtrap/Projects/Requests/ProjectRequestExtensions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ProjectRequestExtensions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Projects.Requests;
+﻿namespace Mailtrap.Projects.Requests;
 
 
 internal static class ProjectRequestExtensions

--- a/src/Mailtrap/Projects/Requests/UpdateProjectRequestDto.cs
+++ b/src/Mailtrap/Projects/Requests/UpdateProjectRequestDto.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UpdateProjectRequestDto.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.Projects.Requests;
+﻿namespace Mailtrap.Projects.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap/SendingDomains/Requests/CreateSendingDomainRequestDto.cs
+++ b/src/Mailtrap/SendingDomains/Requests/CreateSendingDomainRequestDto.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="CreateSendingDomainRequestDto.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.SendingDomains.Requests;
+﻿namespace Mailtrap.SendingDomains.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap/SendingDomains/Requests/GetAllSendingDomainResponseDto.cs
+++ b/src/Mailtrap/SendingDomains/Requests/GetAllSendingDomainResponseDto.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="GetAllSendingDomainResponseDto.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.SendingDomains.Requests;
+﻿namespace Mailtrap.SendingDomains.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap/SendingDomains/Requests/SendingDomainRequestExtensions.cs
+++ b/src/Mailtrap/SendingDomains/Requests/SendingDomainRequestExtensions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendingDomainRequestExtensions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.SendingDomains.Requests;
+﻿namespace Mailtrap.SendingDomains.Requests;
 
 
 internal static class SendingDomainRequestExtensions

--- a/src/Mailtrap/SendingDomains/SendingDomainCollectionResource.cs
+++ b/src/Mailtrap/SendingDomains/SendingDomainCollectionResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendingDomainCollectionResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.SendingDomains;
+﻿namespace Mailtrap.SendingDomains;
 
 
 internal sealed class SendingDomainCollectionResource : RestResource, ISendingDomainCollectionResource

--- a/src/Mailtrap/SendingDomains/SendingDomainResource.cs
+++ b/src/Mailtrap/SendingDomains/SendingDomainResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendingDomainResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.SendingDomains;
+﻿namespace Mailtrap.SendingDomains;
 
 
 internal sealed class SendingDomainResource : RestResource, ISendingDomainResource

--- a/src/Mailtrap/TestingMessages/Requests/TestingMessageRequestExtensions.cs
+++ b/src/Mailtrap/TestingMessages/Requests/TestingMessageRequestExtensions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="TestingMessageRequestExtensions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Requests;
+﻿namespace Mailtrap.TestingMessages.Requests;
 
 
 internal static class TestingMessageRequestExtensions

--- a/src/Mailtrap/TestingMessages/Requests/UpdateTestingMessageRequestDto.cs
+++ b/src/Mailtrap/TestingMessages/Requests/UpdateTestingMessageRequestDto.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UpdateTestingMessageRequestDto.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages.Requests;
+﻿namespace Mailtrap.TestingMessages.Requests;
 
 
 /// <summary>

--- a/src/Mailtrap/TestingMessages/TestingMessageCollectionResource.cs
+++ b/src/Mailtrap/TestingMessages/TestingMessageCollectionResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="TestingMessageCollectionResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages;
+﻿namespace Mailtrap.TestingMessages;
 
 
 internal sealed class TestingMessageCollectionResource : RestResource, ITestingMessageCollectionResource

--- a/src/Mailtrap/TestingMessages/TestingMessageResource.cs
+++ b/src/Mailtrap/TestingMessages/TestingMessageResource.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="TestingMessageResource.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.TestingMessages;
+﻿namespace Mailtrap.TestingMessages;
 
 
 internal sealed class TestingMessageResource : RestResource, ITestingMessageResource

--- a/tests/Mailtrap.IntegrationTests/AccountAccesses/AccountAccessesIntegrationTests.cs
+++ b/tests/Mailtrap.IntegrationTests/AccountAccesses/AccountAccessesIntegrationTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AccountAccessesIntegrationTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.IntegrationTests.AccountAccesses;
+﻿namespace Mailtrap.IntegrationTests.AccountAccesses;
 
 
 [TestFixture]

--- a/tests/Mailtrap.IntegrationTests/Accounts/AccountsIntegrationTests.cs
+++ b/tests/Mailtrap.IntegrationTests/Accounts/AccountsIntegrationTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AccountsIntegrationTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.IntegrationTests.Accounts;
+﻿namespace Mailtrap.IntegrationTests.Accounts;
 
 
 [TestFixture]

--- a/tests/Mailtrap.IntegrationTests/Attachments/AttachmentsIntegrationTests.cs
+++ b/tests/Mailtrap.IntegrationTests/Attachments/AttachmentsIntegrationTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AttachmentsIntegrationTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.IntegrationTests.Attachments;
+﻿namespace Mailtrap.IntegrationTests.Attachments;
 
 
 [TestFixture]

--- a/tests/Mailtrap.IntegrationTests/Billing/BillingIntegrationTests.cs
+++ b/tests/Mailtrap.IntegrationTests/Billing/BillingIntegrationTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="BillingIntegrationTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.IntegrationTests.Billing;
+﻿namespace Mailtrap.IntegrationTests.Billing;
 
 
 [TestFixture]

--- a/tests/Mailtrap.IntegrationTests/Emails/SendEmailIntegrationTests.cs
+++ b/tests/Mailtrap.IntegrationTests/Emails/SendEmailIntegrationTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailIntegrationTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.IntegrationTests.Emails;
+﻿namespace Mailtrap.IntegrationTests.Emails;
 
 
 [TestFixture]

--- a/tests/Mailtrap.IntegrationTests/GlobalUsings.cs
+++ b/tests/Mailtrap.IntegrationTests/GlobalUsings.cs
@@ -1,10 +1,3 @@
-// -----------------------------------------------------------------------
-// <copyright file="GlobalUsings.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
 global using System.Globalization;
 global using System.Net;
 global using System.Net.Http.Json;

--- a/tests/Mailtrap.IntegrationTests/Inboxes/InboxesIntegrationTests.cs
+++ b/tests/Mailtrap.IntegrationTests/Inboxes/InboxesIntegrationTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="InboxesIntegrationTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.IntegrationTests.Inboxes;
+﻿namespace Mailtrap.IntegrationTests.Inboxes;
 
 
 [TestFixture]

--- a/tests/Mailtrap.IntegrationTests/Permissions/PermissionsIntegrationTests.cs
+++ b/tests/Mailtrap.IntegrationTests/Permissions/PermissionsIntegrationTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="PermissionsIntegrationTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.IntegrationTests.Permissions;
+﻿namespace Mailtrap.IntegrationTests.Permissions;
 
 
 [TestFixture]

--- a/tests/Mailtrap.IntegrationTests/Projects/ProjectsIntegrationTests.cs
+++ b/tests/Mailtrap.IntegrationTests/Projects/ProjectsIntegrationTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ProjectsIntegrationTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.IntegrationTests.Projects;
+﻿namespace Mailtrap.IntegrationTests.Projects;
 
 
 [TestFixture]

--- a/tests/Mailtrap.IntegrationTests/SendingDomains/SendingDomainIntegrationTests.cs
+++ b/tests/Mailtrap.IntegrationTests/SendingDomains/SendingDomainIntegrationTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendingDomainIntegrationTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.IntegrationTests.SendingDomains;
+﻿namespace Mailtrap.IntegrationTests.SendingDomains;
 
 
 [TestFixture]

--- a/tests/Mailtrap.IntegrationTests/TestConstants/ClientTestConstants.cs
+++ b/tests/Mailtrap.IntegrationTests/TestConstants/ClientTestConstants.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ClientTestConstants.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.IntegrationTests.TestConstants;
+﻿namespace Mailtrap.IntegrationTests.TestConstants;
 
 
 internal static class ClientTestConstants

--- a/tests/Mailtrap.IntegrationTests/TestConstants/EndpointsTestConstants.cs
+++ b/tests/Mailtrap.IntegrationTests/TestConstants/EndpointsTestConstants.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EndpointsTestConstants.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.IntegrationTests.TestConstants;
+﻿namespace Mailtrap.IntegrationTests.TestConstants;
 
 
 /// <summary>

--- a/tests/Mailtrap.IntegrationTests/TestConstants/HeaderValuesTestConstants.cs
+++ b/tests/Mailtrap.IntegrationTests/TestConstants/HeaderValuesTestConstants.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HeaderValuesTestConstants.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.IntegrationTests.TestConstants;
+﻿namespace Mailtrap.IntegrationTests.TestConstants;
 
 
 /// <summary>

--- a/tests/Mailtrap.IntegrationTests/TestConstants/UrlSegmentsTestConstants.cs
+++ b/tests/Mailtrap.IntegrationTests/TestConstants/UrlSegmentsTestConstants.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UrlSegmentsTestConstants.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.IntegrationTests.TestConstants;
+﻿namespace Mailtrap.IntegrationTests.TestConstants;
 
 
 internal static class UrlSegmentsTestConstants

--- a/tests/Mailtrap.IntegrationTests/TestExtensions/FileHelpers.cs
+++ b/tests/Mailtrap.IntegrationTests/TestExtensions/FileHelpers.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="FileHelpers.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.IntegrationTests.TestExtensions;
+﻿namespace Mailtrap.IntegrationTests.TestExtensions;
 
 
 internal static class FileHelpers

--- a/tests/Mailtrap.IntegrationTests/TestingMessages/TestingMessagesIntegrationTests.cs
+++ b/tests/Mailtrap.IntegrationTests/TestingMessages/TestingMessagesIntegrationTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="TestingMessagesIntegrationTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.IntegrationTests.TestingMessages;
+﻿namespace Mailtrap.IntegrationTests.TestingMessages;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/AccountAccesses/AccountAccessCollectionResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/AccountAccesses/AccountAccessCollectionResourceTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AccountAccessCollectionResourceTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.AccountAccesses;
+﻿namespace Mailtrap.UnitTests.AccountAccesses;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/AccountAccesses/AccountAccessResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/AccountAccesses/AccountAccessResourceTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AccountAccessResourceTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using AccountAccessResource = Mailtrap.AccountAccesses.AccountAccessResource;
+﻿using AccountAccessResource = Mailtrap.AccountAccesses.AccountAccessResource;
 
 
 namespace Mailtrap.UnitTests.AccountAccesses;

--- a/tests/Mailtrap.UnitTests/AccountAccesses/Models/SpecifierTests.cs
+++ b/tests/Mailtrap.UnitTests/AccountAccesses/Models/SpecifierTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SpecifierTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.AccountAccesses.Models;
+﻿namespace Mailtrap.UnitTests.AccountAccesses.Models;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/AccountAccesses/Requests/UpdatePermissionsRequestItemTests.cs
+++ b/tests/Mailtrap.UnitTests/AccountAccesses/Requests/UpdatePermissionsRequestItemTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UpdatePermissionsRequestItemTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.AccountAccesses.Requests;
+﻿namespace Mailtrap.UnitTests.AccountAccesses.Requests;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/AccountAccesses/Requests/UpdatePermissionsRequestTests.cs
+++ b/tests/Mailtrap.UnitTests/AccountAccesses/Requests/UpdatePermissionsRequestTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UpdatePermissionsRequestTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.AccountAccesses.Requests;
+﻿namespace Mailtrap.UnitTests.AccountAccesses.Requests;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Accounts/AccountCollectionResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/Accounts/AccountCollectionResourceTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AccountCollectionResourceTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Accounts;
+﻿namespace Mailtrap.UnitTests.Accounts;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Accounts/AccountResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/Accounts/AccountResourceTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AccountResourceTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using AccountAccessResource = Mailtrap.AccountAccesses.AccountAccessResource;
+﻿using AccountAccessResource = Mailtrap.AccountAccesses.AccountAccessResource;
 
 
 namespace Mailtrap.UnitTests.Accounts;

--- a/tests/Mailtrap.UnitTests/Attachments/AttachmentCollectionResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/Attachments/AttachmentCollectionResourceTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AttachmentCollectionResourceTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Attachments;
+﻿namespace Mailtrap.UnitTests.Attachments;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Attachments/AttachmentResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/Attachments/AttachmentResourceTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AttachmentResourceTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Attachments;
+﻿namespace Mailtrap.UnitTests.Attachments;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Billing/BillingResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/Billing/BillingResourceTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="BillingResourceTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Billing;
+﻿namespace Mailtrap.UnitTests.Billing;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Configuration/MailtrapClientOptionsTests.cs
+++ b/tests/Mailtrap.UnitTests/Configuration/MailtrapClientOptionsTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="MailtrapClientOptionsTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Configuration;
+﻿namespace Mailtrap.UnitTests.Configuration;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Configuration/MailtrapClientOptionsValidatorTests.cs
+++ b/tests/Mailtrap.UnitTests/Configuration/MailtrapClientOptionsValidatorTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="MailtrapClientOptionsValidatorTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Configuration;
+﻿namespace Mailtrap.UnitTests.Configuration;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Configuration/MailtrapJsonSerializerOptionsTests.cs
+++ b/tests/Mailtrap.UnitTests/Configuration/MailtrapJsonSerializerOptionsTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="MailtrapJsonSerializerOptionsTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Configuration;
+﻿namespace Mailtrap.UnitTests.Configuration;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Constants/ClientTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Constants/ClientTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ClientTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Constants;
+﻿namespace Mailtrap.UnitTests.Core.Constants;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Constants/EndpointsTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Constants/EndpointsTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EndpointsTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Constants;
+﻿namespace Mailtrap.UnitTests.Core.Constants;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Constants/HeaderValuesTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Constants/HeaderValuesTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HeaderValuesTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Constants;
+﻿namespace Mailtrap.UnitTests.Core.Constants;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Constants/UrlSegmentsTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Constants/UrlSegmentsTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UrlSegmentsTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Constants;
+﻿namespace Mailtrap.UnitTests.Core.Constants;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Converters/StringEnumJsonConverterFactoryTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Converters/StringEnumJsonConverterFactoryTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="StringEnumJsonConverterFactoryTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Converters;
+﻿namespace Mailtrap.UnitTests.Core.Converters;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Converters/StringEnumJsonConverterTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Converters/StringEnumJsonConverterTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="StringEnumJsonConverterTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Converters;
+﻿namespace Mailtrap.UnitTests.Core.Converters;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Exceptions/EmptyResponseExceptionTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Exceptions/EmptyResponseExceptionTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EmptyResponseExceptionTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Exceptions;
+﻿namespace Mailtrap.UnitTests.Core.Exceptions;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Extensions/CollectionExtensionsTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Extensions/CollectionExtensionsTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="CollectionExtensionsTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using CollectionExtensions = Mailtrap.Core.Extensions.CollectionExtensions;
+﻿using CollectionExtensions = Mailtrap.Core.Extensions.CollectionExtensions;
 
 
 namespace Mailtrap.UnitTests.Core.Extensions;

--- a/tests/Mailtrap.UnitTests/Core/Extensions/EnsureTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Extensions/EnsureTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EnsureTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Extensions;
+﻿namespace Mailtrap.UnitTests.Core.Extensions;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Extensions/FluentValidationResultExtensionsTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Extensions/FluentValidationResultExtensionsTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="FluentValidationResultExtensionsTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Extensions;
+﻿namespace Mailtrap.UnitTests.Core.Extensions;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Extensions/HttpContentExtensionsTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Extensions/HttpContentExtensionsTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HttpContentExtensionsTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Extensions;
+﻿namespace Mailtrap.UnitTests.Core.Extensions;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Extensions/HttpRequestMessageExtensionsTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Extensions/HttpRequestMessageExtensionsTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HttpRequestMessageExtensionsTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Extensions;
+﻿namespace Mailtrap.UnitTests.Core.Extensions;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Extensions/UriExtensionsTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Extensions/UriExtensionsTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UriExtensionsTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Extensions;
+﻿namespace Mailtrap.UnitTests.Core.Extensions;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Http/HttpRequestContentFactoryTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Http/HttpRequestContentFactoryTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HttpRequestContentFactoryTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Http;
+﻿namespace Mailtrap.UnitTests.Core.Http;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Http/HttpRequestMessageFactoryTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Http/HttpRequestMessageFactoryTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HttpRequestMessageFactoryTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Http;
+﻿namespace Mailtrap.UnitTests.Core.Http;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Http/JsonContentHttpResponseHandlerTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Http/JsonContentHttpResponseHandlerTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="JsonContentHttpResponseHandlerTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Http;
+﻿namespace Mailtrap.UnitTests.Core.Http;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Http/PlainTextHttpResponseHandlerTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Http/PlainTextHttpResponseHandlerTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="PlainTextHttpResponseHandlerTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Http;
+﻿namespace Mailtrap.UnitTests.Core.Http;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Http/StatusCodeHttpResponseHandlerTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Http/StatusCodeHttpResponseHandlerTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="StatusCodeHttpResponseHandlerTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Http;
+﻿namespace Mailtrap.UnitTests.Core.Http;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Models/DispositionTypeTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Models/DispositionTypeTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="DispositionTypeTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Models;
+﻿namespace Mailtrap.UnitTests.Core.Models;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Models/ResourceTypeTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Models/ResourceTypeTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ResourceTypeTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Models;
+﻿namespace Mailtrap.UnitTests.Core.Models;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Models/StringEnumTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Models/StringEnumTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="StringEnumTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Core.Models;
+﻿namespace Mailtrap.UnitTests.Core.Models;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Core/Validation/ValidationResultTests.cs
+++ b/tests/Mailtrap.UnitTests/Core/Validation/ValidationResultTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ValidationResultTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using ValidationResult = Mailtrap.Core.Validation.ValidationResult;
+﻿using ValidationResult = Mailtrap.Core.Validation.ValidationResult;
 
 
 namespace Mailtrap.UnitTests.Core.Validation;

--- a/tests/Mailtrap.UnitTests/Emails/EmailClientEndpointProviderTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/EmailClientEndpointProviderTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EmailClientEndpointProviderTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails;
+﻿namespace Mailtrap.UnitTests.Emails;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/EmailClientFactoryTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/EmailClientFactoryTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EmailClientFactoryTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails;
+﻿namespace Mailtrap.UnitTests.Emails;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/EmailClientTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/EmailClientTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EmailClientTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails;
+﻿namespace Mailtrap.UnitTests.Emails;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/Models/AttachmentTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Models/AttachmentTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AttachmentTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Models;
+﻿namespace Mailtrap.UnitTests.Emails.Models;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/Models/EmailAddressTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Models/EmailAddressTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EmailAddressTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Models;
+﻿namespace Mailtrap.UnitTests.Emails.Models;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Attachment.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Attachment.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilderTests.Attachment.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Requests;
+﻿namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Bcc.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Bcc.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilderTests.Bcc.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Requests;
+﻿namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Category.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Category.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilderTests.Category.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Requests;
+﻿namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Cc.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Cc.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilderTests.Cc.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Requests;
+﻿namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.CustomVariable.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.CustomVariable.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilderTests.CustomVariable.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using Variable = System.Collections.Generic.KeyValuePair<string, string>;
+﻿using Variable = System.Collections.Generic.KeyValuePair<string, string>;
 
 
 namespace Mailtrap.UnitTests.Emails.Requests;

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.From.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.From.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilderTests.From.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Requests;
+﻿namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Header.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Header.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilderTests.Header.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-using Header = System.Collections.Generic.KeyValuePair<string, string>;
+﻿using Header = System.Collections.Generic.KeyValuePair<string, string>;
 
 
 namespace Mailtrap.UnitTests.Emails.Requests;

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.HtmlBody.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.HtmlBody.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilderTests.HtmlBody.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Requests;
+﻿namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.ReplyTo.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.ReplyTo.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilderTests.ReplyTo.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Requests;
+﻿namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Subject.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Subject.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilderTests.Subject.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Requests;
+﻿namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Template.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.Template.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilderTests.Template.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Requests;
+﻿namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.TemplateVariables.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.TemplateVariables.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilderTests.TemplateVariables.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Requests;
+﻿namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.TextBody.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.TextBody.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilderTests.TextBody.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Requests;
+﻿namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.To.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestBuilderTests.To.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestBuilderTests.To.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Requests;
+﻿namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture(TestOf = typeof(SendEmailRequestBuilder))]

--- a/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Requests/SendEmailRequestTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Requests;
+﻿namespace Mailtrap.UnitTests.Emails.Requests;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/Responses/SendEmailResponseTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Responses/SendEmailResponseTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailResponseTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Responses;
+﻿namespace Mailtrap.UnitTests.Emails.Responses;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/Validators/AttachmentValidatorTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Validators/AttachmentValidatorTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="AttachmentValidatorTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Validators;
+﻿namespace Mailtrap.UnitTests.Emails.Validators;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/Validators/EmailAddressValidatorTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Validators/EmailAddressValidatorTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EmailAddressValidatorTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Validators;
+﻿namespace Mailtrap.UnitTests.Emails.Validators;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Emails/Validators/SendEmailRequestValidatorTests.cs
+++ b/tests/Mailtrap.UnitTests/Emails/Validators/SendEmailRequestValidatorTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendEmailRequestValidatorTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Emails.Validators;
+﻿namespace Mailtrap.UnitTests.Emails.Validators;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/GlobalUsings.cs
+++ b/tests/Mailtrap.UnitTests/GlobalUsings.cs
@@ -1,10 +1,3 @@
-// -----------------------------------------------------------------------
-// <copyright file="GlobalUsings.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
 global using System.Net;
 global using System.Net.Http.Headers;
 global using System.Net.Http.Json;

--- a/tests/Mailtrap.UnitTests/Inboxes/InboxCollectionResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/Inboxes/InboxCollectionResourceTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="InboxCollectionResourceTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Inboxes;
+﻿namespace Mailtrap.UnitTests.Inboxes;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Inboxes/InboxResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/Inboxes/InboxResourceTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="InboxResourceTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Inboxes;
+﻿namespace Mailtrap.UnitTests.Inboxes;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Inboxes/Requests/CreateInboxRequestTests.cs
+++ b/tests/Mailtrap.UnitTests/Inboxes/Requests/CreateInboxRequestTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="CreateInboxRequestTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Inboxes.Requests;
+﻿namespace Mailtrap.UnitTests.Inboxes.Requests;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/MailtrapClientFactoryTests.cs
+++ b/tests/Mailtrap.UnitTests/MailtrapClientFactoryTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="MailtrapClientFactoryTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests;
+﻿namespace Mailtrap.UnitTests;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/MailtrapClientServiceCollectionExtensionsTests.cs
+++ b/tests/Mailtrap.UnitTests/MailtrapClientServiceCollectionExtensionsTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="MailtrapClientServiceCollectionExtensionsTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests;
+﻿namespace Mailtrap.UnitTests;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/MailtrapClientTests.cs
+++ b/tests/Mailtrap.UnitTests/MailtrapClientTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="MailtrapClientTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests;
+﻿namespace Mailtrap.UnitTests;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Permissions/PermissionsResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/Permissions/PermissionsResourceTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="PermissionsResourceTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Permissions;
+﻿namespace Mailtrap.UnitTests.Permissions;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Projects/ProjectCollectionResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/Projects/ProjectCollectionResourceTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ProjectCollectionResourceTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Projects;
+﻿namespace Mailtrap.UnitTests.Projects;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Projects/ProjectResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/Projects/ProjectResourceTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ProjectResourceTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Projects;
+﻿namespace Mailtrap.UnitTests.Projects;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/Projects/Requests/ProjectRequestTests.cs
+++ b/tests/Mailtrap.UnitTests/Projects/Requests/ProjectRequestTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ProjectRequestTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.Projects.Requests;
+﻿namespace Mailtrap.UnitTests.Projects.Requests;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/SendingDomains/Requests/CreateSendingDomainRequestTests.cs
+++ b/tests/Mailtrap.UnitTests/SendingDomains/Requests/CreateSendingDomainRequestTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="CreateSendingDomainRequestTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.SendingDomains.Requests;
+﻿namespace Mailtrap.UnitTests.SendingDomains.Requests;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/SendingDomains/Requests/SendingDomainInstructionsRequestTests.cs
+++ b/tests/Mailtrap.UnitTests/SendingDomains/Requests/SendingDomainInstructionsRequestTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendingDomainInstructionsRequestTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.SendingDomains.Requests;
+﻿namespace Mailtrap.UnitTests.SendingDomains.Requests;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/SendingDomains/SendingDomainCollectionResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/SendingDomains/SendingDomainCollectionResourceTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendingDomainCollectionResourceTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.SendingDomains;
+﻿namespace Mailtrap.UnitTests.SendingDomains;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/SendingDomains/SendingDomainResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/SendingDomains/SendingDomainResourceTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="SendingDomainResourceTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.SendingDomains;
+﻿namespace Mailtrap.UnitTests.SendingDomains;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/TestConstants/ClientTestConstants.cs
+++ b/tests/Mailtrap.UnitTests/TestConstants/ClientTestConstants.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ClientTestConstants.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.TestConstants;
+﻿namespace Mailtrap.UnitTests.TestConstants;
 
 
 internal static class ClientTestConstants

--- a/tests/Mailtrap.UnitTests/TestConstants/EndpointsTestConstants.cs
+++ b/tests/Mailtrap.UnitTests/TestConstants/EndpointsTestConstants.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="EndpointsTestConstants.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.TestConstants;
+﻿namespace Mailtrap.UnitTests.TestConstants;
 
 
 /// <summary>

--- a/tests/Mailtrap.UnitTests/TestConstants/HeaderValuesTestConstants.cs
+++ b/tests/Mailtrap.UnitTests/TestConstants/HeaderValuesTestConstants.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="HeaderValuesTestConstants.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.TestConstants;
+﻿namespace Mailtrap.UnitTests.TestConstants;
 
 
 /// <summary>

--- a/tests/Mailtrap.UnitTests/TestConstants/UrlSegmentsTestConstants.cs
+++ b/tests/Mailtrap.UnitTests/TestConstants/UrlSegmentsTestConstants.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UrlSegmentsTestConstants.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.TestConstants;
+﻿namespace Mailtrap.UnitTests.TestConstants;
 
 
 internal static class UrlSegmentsTestConstants

--- a/tests/Mailtrap.UnitTests/TestExtensions/JsonConverterTestExtensions.cs
+++ b/tests/Mailtrap.UnitTests/TestExtensions/JsonConverterTestExtensions.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="JsonConverterTestExtensions.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.TestExtensions;
+﻿namespace Mailtrap.UnitTests.TestExtensions;
 
 
 internal static class JsonConverterTestExtensions

--- a/tests/Mailtrap.UnitTests/TestExtensions/JsonHelpers.cs
+++ b/tests/Mailtrap.UnitTests/TestExtensions/JsonHelpers.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="JsonHelpers.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.TestExtensions;
+﻿namespace Mailtrap.UnitTests.TestExtensions;
 
 
 internal static class JsonHelpers

--- a/tests/Mailtrap.UnitTests/TestExtensions/ResourceValidator.cs
+++ b/tests/Mailtrap.UnitTests/TestExtensions/ResourceValidator.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ResourceValidator.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.TestExtensions;
+﻿namespace Mailtrap.UnitTests.TestExtensions;
 
 
 internal static class ResourceValidator

--- a/tests/Mailtrap.UnitTests/TestingMessages/Requests/ForwardTestingMessageRequestTests.cs
+++ b/tests/Mailtrap.UnitTests/TestingMessages/Requests/ForwardTestingMessageRequestTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="ForwardTestingMessageRequestTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.TestingMessages.Requests;
+﻿namespace Mailtrap.UnitTests.TestingMessages.Requests;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/TestingMessages/Requests/UpdateTestingMessageRequestTests.cs
+++ b/tests/Mailtrap.UnitTests/TestingMessages/Requests/UpdateTestingMessageRequestTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="UpdateTestingMessageRequestTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.TestingMessages.Requests;
+﻿namespace Mailtrap.UnitTests.TestingMessages.Requests;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/TestingMessages/TestingMessageCollectionResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/TestingMessages/TestingMessageCollectionResourceTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="TestingMessageCollectionResourceTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.TestingMessages;
+﻿namespace Mailtrap.UnitTests.TestingMessages;
 
 
 [TestFixture]

--- a/tests/Mailtrap.UnitTests/TestingMessages/TestingMessageResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/TestingMessages/TestingMessageResourceTests.cs
@@ -1,11 +1,4 @@
-﻿// -----------------------------------------------------------------------
-// <copyright file="TestingMessageResourceTests.cs" company="Railsware Products Studio, LLC">
-// Copyright (c) Railsware Products Studio, LLC. All rights reserved.
-// </copyright>
-// -----------------------------------------------------------------------
-
-
-namespace Mailtrap.UnitTests.TestingMessages;
+﻿namespace Mailtrap.UnitTests.TestingMessages;
 
 
 [TestFixture]


### PR DESCRIPTION
## Motivation
Remove copyright headers from the source files, since project will be distributed under MIT license.
Close #102.

## Description of Changes
Removed copyright header all over the codebase.

## Checklist
- [ ] Acknowledged that contribution is made under the project's [LICENSE](https://github.com/mailtrap/mailtrap-dotnet/blob/main/LICENSE.md)
- [ ] Confirmed that PR and code/documentation changes are following the [Contributor Code of Conduct](https://github.com/mailtrap/mailtrap-dotnet/blob/main/CODE_OF_CONDUCT.md)
- [ ] PR is properly titled and contains the summary of changes introduced
- [ ] PR branch is based on the latest main branch commit
- [ ] PR contains some meaningful changes, including, but not limited to: functionality, tests, documentation, spelling, etc.
- [ ] Added/updated XMLDoc and inline comments in the code, according to the changes made
- [ ] Added/updated unit tests for added/changed functionality (if any)
- [ ] Added/updated documentation files (if applicable)
