### PR TITLE
Disable Contacts::GetAll method from .NET client

### DIFF
--- a/examples/Mailtrap.Example.Contact/Program.cs
+++ b/examples/Mailtrap.Example.Contact/Program.cs
@@ -32,7 +32,8 @@ try
     IContactCollectionResource contactsResource = accountResource.Contacts();
 
     // Get all contacts for account
-    IList<Contact> contacts = await contactsResource.GetAll();
+    // TODO: Enable when GetAll is implemented
+    IList<Contact> contacts = /*await contactsResource.GetAll()*/ [];
 
     Contact? contact = contacts
         .FirstOrDefault(p => string.Equals(p.Email, contactEmail, StringComparison.OrdinalIgnoreCase));

--- a/examples/Mailtrap.Example.ContactEvents/Program.cs
+++ b/examples/Mailtrap.Example.ContactEvents/Program.cs
@@ -33,7 +33,8 @@ try
     IContactCollectionResource contactsResource = accountResource.Contacts();
 
     // Get all contacts for account
-    IList<Contact> contacts = await contactsResource.GetAll();
+    // TODO: Enable when GetAll is implemented
+    IList<Contact> contacts = /*await contactsResource.GetAll()*/ [];
 
     Contact? contact = contacts.Count > 0 ? contacts[0] : null;
     if (contact is null)

--- a/src/Mailtrap.Abstractions/Contacts/IContactCollectionResource.cs
+++ b/src/Mailtrap.Abstractions/Contacts/IContactCollectionResource.cs
@@ -97,19 +97,6 @@ public interface IContactCollectionResource : IRestResource
     public IContactEventCollectionResource Events(string contactId);
 
     /// <summary>
-    /// Gets collection of contact details.
-    /// </summary>
-    ///
-    /// <param name="cancellationToken">
-    /// Token to control operation cancellation.
-    /// </param>
-    ///
-    /// <returns>
-    /// Collection of contact details.
-    /// </returns>
-    public Task<IList<Contact>> GetAll(CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Creates a new contact with details specified by <paramref name="request"/>.
     /// </summary>
     ///
@@ -118,7 +105,7 @@ public interface IContactCollectionResource : IRestResource
     /// </param>
     ///
     /// <param name="cancellationToken">
-    /// <inheritdoc cref="GetAll(CancellationToken)" path="/param[@name='cancellationToken']"/>
+    /// Token to control operation cancellation.
     /// </param>
     ///
     /// <returns>

--- a/tests/Mailtrap.IntegrationTests/Contacts/ContactsIntegrationTests.cs
+++ b/tests/Mailtrap.IntegrationTests/Contacts/ContactsIntegrationTests.cs
@@ -29,46 +29,46 @@ internal sealed class ContactsIntegrationTests
         _jsonSerializerOptions = _clientConfig.ToJsonSerializerOptions();
     }
 
+    // TODO: Enable when GetAll is implemented
+    // [Test]
+    // public async Task GetAll_Success()
+    // {
+    //     // Arrange
+    //     var httpMethod = HttpMethod.Get;
+    //     var requestUri = _resourceUri.AbsoluteUri;
 
-    [Test]
-    public async Task GetAll_Success()
-    {
-        // Arrange
-        var httpMethod = HttpMethod.Get;
-        var requestUri = _resourceUri.AbsoluteUri;
+    //     using var responseContent = await Feature.LoadFileToStringContent();
 
-        using var responseContent = await Feature.LoadFileToStringContent();
+    //     using var mockHttp = new MockHttpMessageHandler();
+    //     mockHttp
+    //         .Expect(httpMethod, requestUri)
+    //         .WithHeaders("Authorization", $"Bearer {_clientConfig.ApiToken}")
+    //         .WithHeaders("Accept", MimeTypes.Application.Json)
+    //         .WithHeaders("User-Agent", HeaderValues.UserAgent.ToString())
+    //         .Respond(HttpStatusCode.OK, responseContent);
 
-        using var mockHttp = new MockHttpMessageHandler();
-        mockHttp
-            .Expect(httpMethod, requestUri)
-            .WithHeaders("Authorization", $"Bearer {_clientConfig.ApiToken}")
-            .WithHeaders("Accept", MimeTypes.Application.Json)
-            .WithHeaders("User-Agent", HeaderValues.UserAgent.ToString())
-            .Respond(HttpStatusCode.OK, responseContent);
+    //     var serviceCollection = new ServiceCollection();
+    //     serviceCollection
+    //         .AddMailtrapClient(_clientConfig)
+    //         .ConfigurePrimaryHttpMessageHandler(() => mockHttp);
 
-        var serviceCollection = new ServiceCollection();
-        serviceCollection
-            .AddMailtrapClient(_clientConfig)
-            .ConfigurePrimaryHttpMessageHandler(() => mockHttp);
+    //     using var services = serviceCollection.BuildServiceProvider();
+    //     var client = services.GetRequiredService<IMailtrapClient>();
 
-        using var services = serviceCollection.BuildServiceProvider();
-        var client = services.GetRequiredService<IMailtrapClient>();
+    //     // Act
+    //     var result = await client
+    //         .Account(_accountId)
+    //         .Contacts()
+    //         .GetAll()
+    //         .ConfigureAwait(false);
 
-        // Act
-        var result = await client
-            .Account(_accountId)
-            .Contacts()
-            .GetAll()
-            .ConfigureAwait(false);
+    //     // Assert
+    //     mockHttp.VerifyNoOutstandingExpectation();
 
-        // Assert
-        mockHttp.VerifyNoOutstandingExpectation();
-
-        result.Should()
-            .NotBeNull().And
-            .HaveCount(3);
-    }
+    //     result.Should()
+    //         .NotBeNull().And
+    //         .HaveCount(3);
+    // }
 
     [Test]
     public async Task Create_Success()


### PR DESCRIPTION
Disable Contacts::GetAll method temporary because backend implementation is not complete

## Motivation
Backend still doesn't support GetAll for Contatcs API, so need to temporary remove it from .NET client
This update for issue #126 

## Changes

- Removed GetAll from IContactCollectionResource
- Updated Contacts and ContactEvents example projects with respect of removed GetAll functionality
- Updated Integration tests for Contacts API (disabled corresponding tests)

## How to test

- [ ] Run example project [Mailtrap.Example.Contact](https://github.com/railsware/mailtrap-dotnet/tree/6862b42fd1f45c367a2a812656702e8eab1fe07b/examples/Mailtrap.Example.Contact)
- [ ] Run example project [Mailtrap.Example.ContactEvents](https://github.com/railsware/mailtrap-dotnet/tree/6862b42fd1f45c367a2a812656702e8eab1fe07b/examples/Mailtrap.Example.ContactEvents)
- [ ] Run tests from [ContactsIntegrationTests.cs](https://github.com/railsware/mailtrap-dotnet/blob/6862b42fd1f45c367a2a812656702e8eab1fe07b/tests/Mailtrap.IntegrationTests/Contacts/ContactsIntegrationTests.cs)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the ability to retrieve all contacts. Applications depending on this functionality will require updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->