### PR TITLE
Update repository references from "railsware" to "mailtrap" in docume…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Also, by participating, you give your permission to license your contributions i
 Kindly consider searching for already existing issue or feature proposal before creating a new one.  
 Do not increase the entropy unnecessarily - the Universe will appreciate it.
 
-If it is still the case - please use [Issues](https://github.com/railsware/mailtrap-dotnet/issues) section of the repo to file an issue, 
+If it is still the case - please use [Issues](https://github.com/mailtrap/mailtrap-dotnet/issues) section of the repo to file an issue, 
 possible improvement or feature proposal.  
 
 
@@ -47,7 +47,7 @@ Thus you will need to follow steps below to create a new one:
 
 1. Clone the repo
 ```bat
-git clone https://github.com/railsware/mailtrap-dotnet.git
+git clone https://github.com/mailtrap/mailtrap-dotnet.git
 ```
 
 2. Create new branch
@@ -68,7 +68,7 @@ Usage of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#s
 
 5. Push to the remote.
 
-6. Finally, create a pull request to the [main](https://github.com/railsware/mailtrap-dotnet/tree/main) branch, 
+6. Finally, create a pull request to the [main](https://github.com/mailtrap/mailtrap-dotnet/tree/main) branch, 
 using the template provided.  
 Please consider providing detailed description what was changed and validating PR checklist to streamline the PR review.
 
@@ -90,7 +90,7 @@ You can improve SDK documentation in several ways.
 They are used to show inline help in IDE and to generate SDK API reference section of documentation website,
 thus are a crucial part of the SDK.
 
-#### Update markdown files in the [docs](https://github.com/railsware/mailtrap-dotnet/tree/main/docs) folder of the repo.  
+#### Update markdown files in the [docs](https://github.com/mailtrap/mailtrap-dotnet/tree/main/docs) folder of the repo.  
 Considering that [docfx](https://dotnet.github.io/docfx/docs/basic-concepts.html) tool is used to create documentation website
 from sources, please ensure that you are using [supported syntax](https://dotnet.github.io/docfx/docs/markdown.html).
 

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -9,7 +9,7 @@
   </packageRestore>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="github-railsware" value="https://nuget.pkg.github.com/railsware/index.json" />
+    <add key="github-mailtrap" value="https://nuget.pkg.github.com/mailtrap/index.json" />
   </packageSources>
   <packageSourceMapping>
     <!-- key value for <packageSource> should match key values from <packageSources> element -->
@@ -18,12 +18,12 @@
     </packageSource>
   </packageSourceMapping>
   <packageSourceCredentials>
-    <github-railsware>
+    <github-mailtrap>
       <!-- NOTE: Replace USERNAME with your GitHub username when publishing to GitHub Packages -->
       <add key="Username" value="USERNAME" />
       <!-- NOTE: Replace TOKEN with your GitHub personal access token (classic) when publishing to
       GitHub Packages -->
       <add key="ClearTextPassword" value="TOKEN" />
-    </github-railsware>
+    </github-mailtrap>
   </packageSourceCredentials>
 </configuration>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![Mailtrap](assets/img/mailtrap-logo.svg)
 
-[![GitHub Package Version](https://img.shields.io/github/v/release/railsware/mailtrap-dotnet?label=GitHub%20Packages)](https://github.com/orgs/railsware/packages/nuget/package/Mailtrap)
-[![CI](https://github.com/railsware/mailtrap-dotnet/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/railsware/mailtrap-dotnet/actions/workflows/build.yml)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/railsware/mailtrap-dotnet/blob/main/LICENSE.md)
+[![GitHub Package Version](https://img.shields.io/github/v/release/mailtrap/mailtrap-dotnet?label=GitHub%20Packages)](https://github.com/orgs/mailtrap/packages/nuget/package/Mailtrap)
+[![CI](https://github.com/mailtrap/mailtrap-dotnet/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/mailtrap/mailtrap-dotnet/actions/workflows/build.yml)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/mailtrap/mailtrap-dotnet/blob/main/LICENSE.md)
 
 # Official Mailtrap .NET Client
 Welcome to the official [Mailtrap](https://mailtrap.io/) .NET Client repository.  
@@ -52,19 +52,19 @@ The Mailtrap .NET client packages are available through GitHub Packages.
 First, add the GitHub Packages source to your NuGet configuration:
 
 ```console
-dotnet nuget add source https://nuget.pkg.github.com/railsware/index.json --name github-railsware
+dotnet nuget add source https://nuget.pkg.github.com/mailtrap/index.json --name github-mailtrap
 ```
 
 Then add Mailtrap package:
 
 ```console
-dotnet add package Mailtrap -v 2.0.0 -s github-railsware
+dotnet add package Mailtrap -v 2.0.0 -s github-mailtrap
 ```
 
 Optionally, you can add Mailtrap.Abstractions package:
 
 ```console
-dotnet add package Mailtrap.Abstractions -v 2.0.0 -s github-railsware
+dotnet add package Mailtrap.Abstractions -v 2.0.0 -s github-mailtrap
 ```
 
 ### Configure
@@ -180,7 +180,7 @@ The repository includes comprehensive examples demonstrating various use cases a
 Each example includes detailed comments and demonstrates best practices for error handling, configuration, and resource management.
 
 ## Documentation
-Please visit [Documentation Portal](https://railsware.github.io/mailtrap-dotnet/) for detailed setup, configuration and usage instructions.
+Please visit [Documentation Portal](https://mailtrap.github.io/mailtrap-dotnet/) for detailed setup, configuration and usage instructions.
 
 
 ## Contributing

--- a/build/mailtrap-nuget.props
+++ b/build/mailtrap-nuget.props
@@ -6,11 +6,11 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageProjectUrl>https://github.com/railsware/mailtrap-dotnet</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/railsware/mailtrap-dotnet</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/mailtrap/mailtrap-dotnet</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/mailtrap/mailtrap-dotnet</RepositoryUrl>
 
-    <!-- 
-      SourceLink generation settings 
+    <!--
+      SourceLink generation settings
       https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/
     -->
     <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->

--- a/docs/cookbook/send-email.md
+++ b/docs/cookbook/send-email.md
@@ -337,4 +337,4 @@ var response = await emailClient.Send(request);
 
 
 ## See also
-More examples available [here](https://github.com/railsware/mailtrap-dotnet/tree/main/examples).
+More examples available [here](https://github.com/mailtrap/mailtrap-dotnet/tree/main/examples).

--- a/docs/getting-started/configuration-client-di.md
+++ b/docs/getting-started/configuration-client-di.md
@@ -166,7 +166,7 @@ IHost host = hostBuilder.Build();
 
 
 ## What's next
-Additional examples for client configuration within DI container can be found on [GitHub](https://github.com/railsware/mailtrap-dotnet/blob/main/examples/Mailtrap.Example.DependencyInjection/Program.cs)
+Additional examples for client configuration within DI container can be found on [GitHub](https://github.com/mailtrap/mailtrap-dotnet/blob/main/examples/Mailtrap.Example.DependencyInjection/Program.cs)
 
 [!INCLUDE [cookbook-link](../includes/cookbook-link.md)]
 

--- a/docs/getting-started/configuration-client-factory.md
+++ b/docs/getting-started/configuration-client-factory.md
@@ -91,7 +91,7 @@ IMailtrapClient client = factory.CreateClient();
 
 
 ## What's next
-Additional examples of the Mailtrap API client factory configuration and usage can be found on [GitHub](https://github.com/railsware/mailtrap-dotnet/blob/main/examples/Mailtrap.Example.Factory/Program.cs)
+Additional examples of the Mailtrap API client factory configuration and usage can be found on [GitHub](https://github.com/mailtrap/mailtrap-dotnet/blob/main/examples/Mailtrap.Example.Factory/Program.cs)
 
 [!INCLUDE [cookbook-link](../includes/cookbook-link.md)]
 

--- a/docs/includes/examples-link.md
+++ b/docs/includes/examples-link.md
@@ -1,1 +1,1 @@
-Also a bunch of examples is available in the [Source Repository](https://github.com/railsware/mailtrap-dotnet/tree/main/examples).
+Also a bunch of examples is available in the [Source Repository](https://github.com/mailtrap/mailtrap-dotnet/tree/main/examples).

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Section with detailed [setup instructions](xref:setup) and advanced [configurati
 - [Cookbook](xref:send-email)  
 Various use-cases and recipes for API features.
 
-- [Examples](https://github.com/railsware/mailtrap-dotnet/tree/main/examples)  
+- [Examples](https://github.com/mailtrap/mailtrap-dotnet/tree/main/examples)  
 Repository with sample projects with different usage scenarios.
 
 - [API Reference](xref:Mailtrap)  
@@ -24,8 +24,8 @@ Detailed API reference.
 
 <!-- ## Contributing
 We believe in the power of OSS and welcome any contributions to the library.  
-Please refer to [Contributing Guide](https://github.com/railsware/mailtrap-dotnet/tree/main?tab=contrib-ov-file#readme) for details. -->
+Please refer to [Contributing Guide](https://github.com/mailtrap/mailtrap-dotnet/tree/main?tab=contrib-ov-file#readme) for details. -->
 
 
 ## License
-Licensed under the [MIT License](https://github.com/railsware/mailtrap-dotnet/tree/main?tab=MIT-1-ov-file#readme).
+Licensed under the [MIT License](https://github.com/mailtrap/mailtrap-dotnet/tree/main?tab=MIT-1-ov-file#readme).

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -3,13 +3,12 @@
 
 - name: Cookbook
   href: cookbook/
-  
+
 - name: Reference
   uid: Mailtrap
 
 - name: Examples
-  href: https://github.com/railsware/mailtrap-dotnet/tree/main/examples
+  href: https://github.com/mailtrap/mailtrap-dotnet/tree/main/examples
 
 - name: GitHub
-  href: https://github.com/railsware/mailtrap-dotnet
-  
+  href: https://github.com/mailtrap/mailtrap-dotnet

--- a/src/Mailtrap.Abstractions/Mailtrap.Abstractions.csproj
+++ b/src/Mailtrap.Abstractions/Mailtrap.Abstractions.csproj
@@ -11,7 +11,7 @@
     <Authors>Railsware</Authors>
     <Company>Railsware Products Studio, LLC</Company>
     <PackageDescription>Official Mailtrap.io .NET Client Abstractions</PackageDescription>
-    <RepositoryUrl>https://github.com/railsware/mailtrap-dotnet</RepositoryUrl>
+    <RepositoryUrl>https://github.com/mailtrap/mailtrap-dotnet</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Mailtrap.Abstractions/README.md
+++ b/src/Mailtrap.Abstractions/README.md
@@ -2,7 +2,7 @@
 Provides abstractions for the Mailtrap .NET SDK.  
 Interfaces defined in this package are implemented by classes in the [Mailtrap](https://www.nuget.org/packages/Mailtrap) package.
 
-Please visit [documentation site](https://railsware.github.io/mailtrap-dotnet) for detailed documentation and usage examples.
+Please visit [documentation site](https://mailtrap.github.io/mailtrap-dotnet) for detailed documentation and usage examples.
 
 
 ## Main Types
@@ -19,4 +19,4 @@ Please visit [documentation site](https://railsware.github.io/mailtrap-dotnet) f
 
 ## Contributing
 `Mailtrap.Abstractions` package is released as open source under the [MIT license](https://licenses.nuget.org/MIT).
-Bug reports and contributions are welcome at the [GitHub repository](https://github.com/railsware/mailtrap-dotnet).
+Bug reports and contributions are welcome at the [GitHub repository](https://github.com/mailtrap/mailtrap-dotnet).

--- a/src/Mailtrap/Mailtrap.csproj
+++ b/src/Mailtrap/Mailtrap.csproj
@@ -11,7 +11,7 @@
     <Authors>Railsware</Authors>
     <Company>Railsware Products Studio, LLC</Company>
     <PackageDescription>Official Mailtrap.io .NET Client</PackageDescription>
-    <RepositoryUrl>https://github.com/railsware/mailtrap-dotnet</RepositoryUrl>
+    <RepositoryUrl>https://github.com/mailtrap/mailtrap-dotnet</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Mailtrap/README.md
+++ b/src/Mailtrap/README.md
@@ -1,7 +1,7 @@
 # Mailtrap
 Official Mailtrap .NET SDK.
 
-Please visit [documentation site](https://railsware.github.io/mailtrap-dotnet) for detailed documentation and usage examples.
+Please visit [documentation site](https://mailtrap.github.io/mailtrap-dotnet) for detailed documentation and usage examples.
 
 
 ## Main Types
@@ -17,4 +17,4 @@ Please visit [documentation site](https://railsware.github.io/mailtrap-dotnet) f
 
 ## Contributing
 `Mailtrap` package is released as open source under the [MIT license](https://licenses.nuget.org/MIT).
-Bug reports and contributions are welcome at the [GitHub repository](https://github.com/railsware/mailtrap-dotnet).
+Bug reports and contributions are welcome at the [GitHub repository](https://github.com/mailtrap/mailtrap-dotnet).


### PR DESCRIPTION
## Motivation
Update repository references from "railsware" to "mailtrap" in documentation and configuration files

## Changes

- All references changed from "railsware" to "mailtrap"

## How to test

- [ ] Check [readme](https://github.com/mailtrap/mailtrap-dotnet/blob/0cdc391e4adf1b043cca2d0cf39d7a6850fffac2/README.md) 
- [ ] Check [Docs](https://github.com/mailtrap/mailtrap-dotnet/blob/0cdc391e4adf1b043cca2d0cf39d7a6850fffac2/docs/index.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository references from railsware to mailtrap organization across documentation, configuration files, and project metadata.
  * Updated NuGet package source references and documentation portal URLs to reflect the new organization.
  * Updated GitHub repository links and CI badge references throughout documentation and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->