### PR TITLE
Fix install instructions and prepare for v3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [3.0.0] - 2025-11-04
 
 ### Features
 - **Batch Email Support** — Added batch email functionality.
@@ -78,9 +78,6 @@
 | 1.0.0 | 2024-10-08 | Send email + XML docs |
 | 1.0.1 | 2024-12-10 | Multi-API support (Accounts, Projects, Billing, Inboxes) |
 | 2.0.0 | 2025-08-22 | Domain management improvements |
-| Unreleased | — | Contacts ecosystem (Lists, Imports, Events, Exports) |
-|  | — | Batch email |
-|  | — | Suppressions Management |
-|  | — | Email Templates Management |
+| 3.0.0 | 2025-11-04 | Contacts ecosystem (Lists, Imports, Events, Exports), Batch email, Suppressions Management, Email Templates Management |
 
 ---

--- a/README.md
+++ b/README.md
@@ -25,22 +25,26 @@ To get the most out of this official Mailtrap.io .NET SDK:
 
 The Mailtrap .NET client packages are available through GitHub Packages.
 
-Add the GitHub Packages source to your NuGet configuration:
+To add the GitHub Packages source to your NuGet configuration it is required to [authenticate to GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry#authenticating-to-github-packages).
 
 ```bash
-dotnet nuget add source https://nuget.pkg.github.com/mailtrap/index.json --name github-mailtrap
+dotnet nuget add source https://nuget.pkg.github.com/mailtrap/index.json --name github-mailtrap --username GITHUB_USERNAME --password GITHUB_PAT --store-password-in-clear-text
 ```
+
+Replace GITHUB_USERNAME with the username to be used when connecting to an authenticated source.
+
+Replace GITHUB_PAT with the personal access token that is granted at least `read:packages` scope.
 
 Then add the Mailtrap package:
 
 ```bash
-dotnet add package Mailtrap -v 2.0.0 -s github-mailtrap
+dotnet add package Mailtrap -v 3.0.0 -s github-mailtrap
 ```
 
 Optionally, you can add the Mailtrap.Abstractions package:
 
 ```bash
-dotnet add package Mailtrap.Abstractions -v 2.0.0 -s github-mailtrap
+dotnet add package Mailtrap.Abstractions -v 3.0.0 -s github-mailtrap
 ```
 
 ---

--- a/src/Mailtrap.Abstractions/Mailtrap.Abstractions.csproj
+++ b/src/Mailtrap.Abstractions/Mailtrap.Abstractions.csproj
@@ -7,7 +7,7 @@
     <Title>Mailtrap Client Abstractions</Title>
     <PackageId>Mailtrap.Abstractions</PackageId>
     <PackageTags>mailtrap; sdk; client; abstractions; email; smtp</PackageTags>
-    <!-- Now MinVer will handle it <Version>2.0.0</Version> -->
+    <!-- NOTE: `Version` is managed with MinVer -->
     <Authors>Railsware</Authors>
     <Company>Railsware Products Studio, LLC</Company>
     <PackageDescription>Official Mailtrap.io .NET Client Abstractions</PackageDescription>

--- a/src/Mailtrap/Mailtrap.csproj
+++ b/src/Mailtrap/Mailtrap.csproj
@@ -7,7 +7,7 @@
     <Title>Mailtrap Client</Title>
     <PackageId>Mailtrap</PackageId>
     <PackageTags>mailtrap; sdk; client; email; smtp</PackageTags>
-    <!-- Now MinVer will handle it <Version>2.0.0</Version> -->
+    <!-- NOTE: `Version` is managed with MinVer -->
     <Authors>Railsware</Authors>
     <Company>Railsware Products Studio, LLC</Company>
     <PackageDescription>Official Mailtrap.io .NET Client</PackageDescription>


### PR DESCRIPTION
## Motivation

GitHub Packages are public but access requires authentication.

## Changes

- Fix install instructions and prepare for v3.0.0 release

## How to test

- [ ] Try to install the packages on a demo project. You should use version `2.0.0` though as `3.0.0` wasn't released yet.

## Images and GIFs

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to require authentication when adding the NuGet package source and clarified PAT usage.
  * Updated example package references and commands to use version 3.0.0.

* **Chores**
  * Consolidated changelog and labeled release as 3.0.0 (2025-11-04).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->