### PR TITLE
MT-22678: Add name search filter to contact lists GetAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ private static SendEmailRequest TemplateBasedRequest()
 ### Contacts Management
 
 - Contacts management – [`examples/Mailtrap.Example.Contact`](examples/Mailtrap.Example.Contact/)
-- Contact lists management – [`examples/Mailtrap.Example.ContactLists`](examples/Mailtrap.Example.ContactLists/)
+- Contact lists management (list with optional name search filter — case-insensitive prefix match) – [`examples/Mailtrap.Example.ContactLists`](examples/Mailtrap.Example.ContactLists/)
 - Contact fields management – [`examples/Mailtrap.Example.ContactFields`](examples/Mailtrap.Example.ContactFields/)
 - Contact import management – [`examples/Mailtrap.Example.ContactImports`](examples/Mailtrap.Example.ContactImports/)
 - Contact export management – [`examples/Mailtrap.Example.ContactExports`](examples/Mailtrap.Example.ContactExports/)

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ private static SendEmailRequest TemplateBasedRequest()
 ### Contacts Management
 
 - Contacts management – [`examples/Mailtrap.Example.Contact`](examples/Mailtrap.Example.Contact/)
-- Contact lists management (list with optional name search filter — case-insensitive prefix match) – [`examples/Mailtrap.Example.ContactLists`](examples/Mailtrap.Example.ContactLists/)
+- Contact lists management – [`examples/Mailtrap.Example.ContactLists`](examples/Mailtrap.Example.ContactLists/)
 - Contact fields management – [`examples/Mailtrap.Example.ContactFields`](examples/Mailtrap.Example.ContactFields/)
 - Contact import management – [`examples/Mailtrap.Example.ContactImports`](examples/Mailtrap.Example.ContactImports/)
 - Contact export management – [`examples/Mailtrap.Example.ContactExports`](examples/Mailtrap.Example.ContactExports/)

--- a/examples/Mailtrap.Example.ContactLists/Program.cs
+++ b/examples/Mailtrap.Example.ContactLists/Program.cs
@@ -35,6 +35,11 @@ try
     // Get all contact lists for account
     IList<ContactList> contactLists = await contactListsResource.GetAll();
 
+    // Filter contact lists by name (case-insensitive prefix match)
+    var searchFilter = new ContactListListFilter { Search = "news" };
+    IList<ContactList> matchingContactLists = await contactListsResource.GetAll(searchFilter);
+    logger.LogInformation("Found {Count} contact list(s) matching search filter.", matchingContactLists.Count);
+
     ContactList? contactList = contactLists.Count > 0 ? contactLists[0] : null;
 
     if (contactList is null)

--- a/src/Mailtrap.Abstractions/ContactLists/IContactListCollectionResource.cs
+++ b/src/Mailtrap.Abstractions/ContactLists/IContactListCollectionResource.cs
@@ -9,6 +9,12 @@ public interface IContactListCollectionResource : IRestResource
     /// Gets collection of contact list details.
     /// </summary>
     ///
+    /// <param name="filter">
+    /// Optional filter to apply when fetching contact lists.<br />
+    /// When <see cref="ContactListListFilter.Search"/> is specified, only contact lists whose name
+    /// starts with the provided value (case-insensitive prefix match) are returned.
+    /// </param>
+    ///
     /// <param name="cancellationToken">
     /// Token to control operation cancellation.
     /// </param>
@@ -16,7 +22,7 @@ public interface IContactListCollectionResource : IRestResource
     /// <returns>
     /// A collection of contact list details.
     /// </returns>
-    public Task<IList<ContactList>> GetAll(CancellationToken cancellationToken = default);
+    public Task<IList<ContactList>> GetAll(ContactListListFilter? filter = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Creates a new contact list with details specified by <paramref name="request"/>.
@@ -27,7 +33,7 @@ public interface IContactListCollectionResource : IRestResource
     /// </param>
     ///
     /// <param name="cancellationToken">
-    /// <inheritdoc cref="GetAll(CancellationToken)" path="/param[@name='cancellationToken']"/>
+    /// <inheritdoc cref="GetAll(ContactListListFilter, CancellationToken)" path="/param[@name='cancellationToken']"/>
     /// </param>
     ///
     /// <returns>

--- a/src/Mailtrap.Abstractions/ContactLists/IContactListCollectionResource.cs
+++ b/src/Mailtrap.Abstractions/ContactLists/IContactListCollectionResource.cs
@@ -9,12 +9,6 @@ public interface IContactListCollectionResource : IRestResource
     /// Gets collection of contact list details.
     /// </summary>
     ///
-    /// <param name="filter">
-    /// Optional filter to apply when fetching contact lists.<br />
-    /// When <see cref="ContactListListFilter.Search"/> is specified, only contact lists whose name
-    /// starts with the provided value (case-insensitive prefix match) are returned.
-    /// </param>
-    ///
     /// <param name="cancellationToken">
     /// Token to control operation cancellation.
     /// </param>
@@ -22,7 +16,26 @@ public interface IContactListCollectionResource : IRestResource
     /// <returns>
     /// A collection of contact list details.
     /// </returns>
-    public Task<IList<ContactList>> GetAll(ContactListListFilter? filter = null, CancellationToken cancellationToken = default);
+    public Task<IList<ContactList>> GetAll(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets collection of contact list details matching the specified <paramref name="filter"/>.
+    /// </summary>
+    ///
+    /// <param name="filter">
+    /// Filter to apply when fetching contact lists.<br />
+    /// When <see cref="ContactListListFilter.Search"/> is specified, only contact lists whose name
+    /// starts with the provided value (case-insensitive prefix match) are returned.
+    /// </param>
+    ///
+    /// <param name="cancellationToken">
+    /// <inheritdoc cref="GetAll(CancellationToken)" path="/param[@name='cancellationToken']"/>
+    /// </param>
+    ///
+    /// <returns>
+    /// <inheritdoc cref="GetAll(CancellationToken)" path="/returns"/>
+    /// </returns>
+    public Task<IList<ContactList>> GetAll(ContactListListFilter filter, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Creates a new contact list with details specified by <paramref name="request"/>.
@@ -33,7 +46,7 @@ public interface IContactListCollectionResource : IRestResource
     /// </param>
     ///
     /// <param name="cancellationToken">
-    /// <inheritdoc cref="GetAll(ContactListListFilter, CancellationToken)" path="/param[@name='cancellationToken']"/>
+    /// <inheritdoc cref="GetAll(CancellationToken)" path="/param[@name='cancellationToken']"/>
     /// </param>
     ///
     /// <returns>

--- a/src/Mailtrap.Abstractions/ContactLists/Models/ContactListListFilter.cs
+++ b/src/Mailtrap.Abstractions/ContactLists/Models/ContactListListFilter.cs
@@ -1,0 +1,19 @@
+namespace Mailtrap.ContactLists.Models;
+
+
+/// <summary>
+/// Represents a set of filtering parameters for the contact list fetching.
+/// </summary>
+public sealed record ContactListListFilter
+{
+    /// <summary>
+    /// Gets or sets a name to filter contact lists by.<br />
+    /// If specified, only contact lists whose name starts with the provided value
+    /// (case-insensitive prefix match) are returned.
+    /// </summary>
+    ///
+    /// <value>
+    /// Name prefix used to filter contact lists returned by fetch.
+    /// </value>
+    public string? Search { get; set; }
+}

--- a/src/Mailtrap/ContactLists/ContactListCollectionResource.cs
+++ b/src/Mailtrap/ContactLists/ContactListCollectionResource.cs
@@ -11,7 +11,10 @@ internal sealed class ContactListCollectionResource : RestResource, IContactList
     public ContactListCollectionResource(IRestResourceCommandFactory restResourceCommandFactory, Uri resourceUri)
         : base(restResourceCommandFactory, resourceUri) { }
 
-    public async Task<IList<ContactList>> GetAll(ContactListListFilter? filter = null, CancellationToken cancellationToken = default)
+    public async Task<IList<ContactList>> GetAll(CancellationToken cancellationToken = default)
+        => await GetList<ContactList>(CreateListUri(null), cancellationToken).ConfigureAwait(false);
+
+    public async Task<IList<ContactList>> GetAll(ContactListListFilter filter, CancellationToken cancellationToken = default)
         => await GetList<ContactList>(CreateListUri(filter), cancellationToken).ConfigureAwait(false);
 
     public async Task<ContactList> Create(ContactListRequest request, CancellationToken cancellationToken = default)
@@ -20,8 +23,8 @@ internal sealed class ContactListCollectionResource : RestResource, IContactList
 
     private Uri CreateListUri(ContactListListFilter? filter)
     {
-        return filter?.Search is not null && !string.IsNullOrWhiteSpace(filter.Search)
-            ? ResourceUri.AppendQueryParameter(SearchQueryParameter, filter.Search)
+        return !string.IsNullOrWhiteSpace(filter?.Search)
+            ? ResourceUri.AppendQueryParameter(SearchQueryParameter, filter!.Search)
             : ResourceUri;
     }
 }

--- a/src/Mailtrap/ContactLists/ContactListCollectionResource.cs
+++ b/src/Mailtrap/ContactLists/ContactListCollectionResource.cs
@@ -5,12 +5,23 @@
 /// </summary>
 internal sealed class ContactListCollectionResource : RestResource, IContactListCollectionResource
 {
+    private const string SearchQueryParameter = "search";
+
+
     public ContactListCollectionResource(IRestResourceCommandFactory restResourceCommandFactory, Uri resourceUri)
         : base(restResourceCommandFactory, resourceUri) { }
 
-    public async Task<IList<ContactList>> GetAll(CancellationToken cancellationToken = default)
-        => await GetList<ContactList>(cancellationToken).ConfigureAwait(false);
+    public async Task<IList<ContactList>> GetAll(ContactListListFilter? filter = null, CancellationToken cancellationToken = default)
+        => await GetList<ContactList>(CreateListUri(filter), cancellationToken).ConfigureAwait(false);
 
     public async Task<ContactList> Create(ContactListRequest request, CancellationToken cancellationToken = default)
         => await Create<ContactListRequest, ContactList>(request, cancellationToken).ConfigureAwait(false);
+
+
+    private Uri CreateListUri(ContactListListFilter? filter)
+    {
+        return filter?.Search is not null && !string.IsNullOrWhiteSpace(filter.Search)
+            ? ResourceUri.AppendQueryParameter(SearchQueryParameter, filter.Search)
+            : ResourceUri;
+    }
 }

--- a/tests/Mailtrap.UnitTests/ContactLists/ContactListCollectionResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/ContactLists/ContactListCollectionResourceTests.cs
@@ -52,7 +52,7 @@ internal sealed class ContactListCollectionResourceTests
     #region GetAll
 
     [Test]
-    public async Task GetAll_ShouldNotAppendQueryParameters_WhenFilterIsNull()
+    public async Task GetAll_ShouldNotAppendQueryParameters_WhenCalledWithoutFilter()
     {
         // Arrange
         var commandFactoryMock = new Mock<IRestResourceCommandFactory>();
@@ -68,6 +68,29 @@ internal sealed class ContactListCollectionResourceTests
 
         // Act
         await resource.GetAll();
+
+        // Assert
+        commandFactoryMock.Verify(f => f.CreateGet<IList<ContactList>>(_resourceUri), Times.Once);
+    }
+
+    [Test]
+    public async Task GetAll_ShouldNotAppendQueryParameters_WhenFilterSearchIsEmpty()
+    {
+        // Arrange
+        var commandFactoryMock = new Mock<IRestResourceCommandFactory>();
+        var commandMock = new Mock<IRestResourceCommand<IList<ContactList>>>();
+        commandMock
+            .Setup(c => c.Execute(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        commandFactoryMock
+            .Setup(f => f.CreateGet<IList<ContactList>>(It.IsAny<Uri>()))
+            .Returns(commandMock.Object);
+
+        var resource = new ContactListCollectionResource(commandFactoryMock.Object, _resourceUri);
+        var filter = new ContactListListFilter { Search = "   " };
+
+        // Act
+        await resource.GetAll(filter);
 
         // Assert
         commandFactoryMock.Verify(f => f.CreateGet<IList<ContactList>>(_resourceUri), Times.Once);

--- a/tests/Mailtrap.UnitTests/ContactLists/ContactListCollectionResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/ContactLists/ContactListCollectionResourceTests.cs
@@ -48,5 +48,59 @@ internal sealed class ContactListCollectionResourceTests
 
     #endregion
 
+
+    #region GetAll
+
+    [Test]
+    public async Task GetAll_ShouldNotAppendQueryParameters_WhenFilterIsNull()
+    {
+        // Arrange
+        var commandFactoryMock = new Mock<IRestResourceCommandFactory>();
+        var commandMock = new Mock<IRestResourceCommand<IList<ContactList>>>();
+        commandMock
+            .Setup(c => c.Execute(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        commandFactoryMock
+            .Setup(f => f.CreateGet<IList<ContactList>>(It.IsAny<Uri>()))
+            .Returns(commandMock.Object);
+
+        var resource = new ContactListCollectionResource(commandFactoryMock.Object, _resourceUri);
+
+        // Act
+        await resource.GetAll();
+
+        // Assert
+        commandFactoryMock.Verify(f => f.CreateGet<IList<ContactList>>(_resourceUri), Times.Once);
+    }
+
+    [Test]
+    public async Task GetAll_ShouldAppendSearchQueryParameter_WhenFilterSearchIsProvided()
+    {
+        // Arrange
+        var commandFactoryMock = new Mock<IRestResourceCommandFactory>();
+        var commandMock = new Mock<IRestResourceCommand<IList<ContactList>>>();
+        commandMock
+            .Setup(c => c.Execute(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        Uri? capturedUri = null;
+        commandFactoryMock
+            .Setup(f => f.CreateGet<IList<ContactList>>(It.IsAny<Uri>()))
+            .Callback<Uri, string[]>((uri, _) => capturedUri = uri)
+            .Returns(commandMock.Object);
+
+        var resource = new ContactListCollectionResource(commandFactoryMock.Object, _resourceUri);
+        var filter = new ContactListListFilter { Search = "news" };
+
+        // Act
+        await resource.GetAll(filter);
+
+        // Assert
+        capturedUri.Should().NotBeNull();
+        capturedUri!.Query.Should().Be("?search=news");
+    }
+
+    #endregion
+
     private ContactListCollectionResource CreateResource() => new(_commandFactoryMock, _resourceUri);
 }

--- a/tests/Mailtrap.UnitTests/GlobalUsings.cs
+++ b/tests/Mailtrap.UnitTests/GlobalUsings.cs
@@ -35,6 +35,7 @@ global using Mailtrap.ContactExports.Validators;
 global using Mailtrap.ContactImports;
 global using Mailtrap.ContactImports.Requests;
 global using Mailtrap.ContactLists;
+global using Mailtrap.ContactLists.Models;
 global using Mailtrap.ContactLists.Requests;
 global using Mailtrap.ContactFields;
 global using Mailtrap.ContactFields.Models;


### PR DESCRIPTION
## Motivation

https://railsware.atlassian.net/browse/MT-22678

## Changes

- Add a `ContactListListFilter` with an optional `Search` and a `GetAll(filter, ct)` overload — filters contact lists by name (case-insensitive prefix match), per the OpenAPI `GET /api/contacts/lists` param. The token-only `GetAll(ct)` is kept as a separate overload, so existing positional callers still compile.

## How to test

- [ ] `await resource.GetAll()` — returns all contact lists (unchanged behaviour).
- [ ] `await resource.GetAll(new ContactListListFilter { Search = "news" })` — returns only lists whose name starts with "news" (case-insensitive).