### PR TITLE
MT-23076: expose api token expiration in create and reset requests

### DIFF
--- a/examples/Mailtrap.Example.ApiTokens/Program.cs
+++ b/examples/Mailtrap.Example.ApiTokens/Program.cs
@@ -35,10 +35,14 @@ try
     IList<ApiToken> apiTokens = await apiTokensResource.GetAll();
     logger.LogInformation("Found {Count} API token(s).", apiTokens.Count);
 
-    // Create a new API token scoped to a specific inbox with Viewer access
+    // Create a new API token scoped to a specific inbox with Viewer access.
+    // ExpiresAt is optional: omit it for the server default expiration,
+    // use ApiTokenExpiration.Never for a token that never expires,
+    // or ApiTokenExpiration.At(...) for an explicit expiration date.
     var createRequest = new CreateApiTokenRequest
     {
-        Name = "Demo Viewer Token"
+        Name = "Demo Viewer Token",
+        ExpiresAt = ApiTokenExpiration.At(DateTimeOffset.UtcNow.AddMonths(6))
     };
     createRequest.Resources.Add(new ApiTokenAccessRequest(ResourceType.Inbox, inboxId, AccessLevel.Viewer));
 
@@ -62,13 +66,25 @@ try
         tokenDetails.Name,
         tokenDetails.CreatedBy);
 
-    // Reset the API token - expires the current token and returns a new one with the same permissions
+    // Reset the API token - expires the current token and returns a new one with the same permissions.
+    // The parameterless overload keeps the server default expiration for the new token.
     ApiTokenResetResponse resetResponse = await apiTokenResource.Reset();
     logger.LogInformation(
         "Reset API Token: Id={Id}, NewLast4={Last4}",
         resetResponse.Id,
         resetResponse.Last4Digits);
     logger.LogInformation("New token value (store securely, returned only once): {Token}", resetResponse.Token);
+
+    // Reset again, this time requesting a new token that never expires
+    ApiTokenResetResponse neverExpiringToken = await apiTokenResource.Reset(new ResetApiTokenRequest
+    {
+        ExpiresAt = ApiTokenExpiration.Never
+    });
+    logger.LogInformation(
+        "Reset API Token: Id={Id}, NewLast4={Last4}, ExpiresAt={ExpiresAt}",
+        neverExpiringToken.Id,
+        neverExpiringToken.Last4Digits,
+        neverExpiringToken.ExpiresAt);
 
     // Delete the API token
     // The API token resource becomes invalid after deletion and should not be used anymore

--- a/src/Mailtrap.Abstractions/AccountAccesses/Models/Specifier.cs
+++ b/src/Mailtrap.Abstractions/AccountAccesses/Models/Specifier.cs
@@ -80,6 +80,21 @@ public sealed record Specifier
     public string? Token { get; set; }
 
     /// <summary>
+    /// Gets the token value with all but the last characters masked.
+    /// </summary>
+    ///
+    /// <value>
+    /// Token value with all but the last characters masked.
+    /// </value>
+    ///
+    /// <remarks>
+    /// Applicable to 'ApiToken' specifier type only.
+    /// </remarks>
+    [JsonPropertyName("masked_token")]
+    [JsonPropertyOrder(6)]
+    public string? MaskedToken { get; set; }
+
+    /// <summary>
     /// Gets the token expiration date and time.
     /// </summary>
     ///
@@ -91,7 +106,7 @@ public sealed record Specifier
     /// Applicable to 'ApiToken' specifier type only.
     /// </remarks>
     [JsonPropertyName("expires_at")]
-    [JsonPropertyOrder(6)]
+    [JsonPropertyOrder(7)]
     public DateTimeOffset? ExpiresAt { get; set; }
 
     /// <summary>
@@ -107,6 +122,6 @@ public sealed record Specifier
     /// Applicable to 'User' specifier type only.
     /// </remarks>
     [JsonPropertyName("two_factor_authentication_enabled")]
-    [JsonPropertyOrder(7)]
+    [JsonPropertyOrder(8)]
     public bool? TwoFactorAuthEnabled { get; set; }
 }

--- a/src/Mailtrap.Abstractions/ApiTokens/Converters/ApiTokenExpirationJsonConverter.cs
+++ b/src/Mailtrap.Abstractions/ApiTokens/Converters/ApiTokenExpirationJsonConverter.cs
@@ -1,0 +1,40 @@
+namespace Mailtrap.ApiTokens.Converters;
+
+
+/// <summary>
+/// Custom JSON converter to be used for <see cref="ApiTokenExpiration"/>.<br/>
+/// Writes JSON <see langword="null"/> for <see cref="ApiTokenExpiration.Never"/>
+/// and the ISO 8601 date-time string otherwise.
+/// </summary>
+internal sealed class ApiTokenExpirationJsonConverter : JsonConverter<ApiTokenExpiration>
+{
+    public override bool HandleNull => true;
+
+
+    public override ApiTokenExpiration? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.Null => ApiTokenExpiration.Never,
+            JsonTokenType.String => reader.TryGetDateTimeOffset(out var date)
+                ? ApiTokenExpiration.At(date)
+                : throw new JsonException($"Cannot convert value '{reader.GetString()}' to {nameof(ApiTokenExpiration)}."),
+            _ => throw new JsonException($"Unexpected JSON token {reader.TokenType} for {nameof(ApiTokenExpiration)}.")
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, ApiTokenExpiration value, JsonSerializerOptions options)
+    {
+        Ensure.NotNull(writer, nameof(writer));
+        Ensure.NotNull(value, nameof(value));
+
+        if (value.Value.HasValue)
+        {
+            writer.WriteStringValue(value.Value.Value);
+        }
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+}

--- a/src/Mailtrap.Abstractions/ApiTokens/IApiTokenResource.cs
+++ b/src/Mailtrap.Abstractions/ApiTokens/IApiTokenResource.cs
@@ -46,4 +46,27 @@ public interface IApiTokenResource : IRestResource
     /// the new token value — store it securely; it is only returned once.
     /// </remarks>
     public Task<ApiTokenResetResponse> Reset(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reset the API token represented by this resource, specifying an expiration for the new token.
+    /// </summary>
+    ///
+    /// <param name="request">
+    /// Request with the optional expiration for the new token.
+    /// </param>
+    ///
+    /// <param name="cancellationToken">
+    /// Token to control operation cancellation.
+    /// </param>
+    ///
+    /// <returns>
+    /// New API token details, including the full token value.
+    /// </returns>
+    ///
+    /// <remarks>
+    /// Expires the requested token and creates a new token with the same permissions.
+    /// The old token stops working after a short grace period. The response includes
+    /// the new token value – store it securely; it is only returned once.
+    /// </remarks>
+    public Task<ApiTokenResetResponse> Reset(ResetApiTokenRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/Mailtrap.Abstractions/ApiTokens/Models/ApiTokenExpiration.cs
+++ b/src/Mailtrap.Abstractions/ApiTokens/Models/ApiTokenExpiration.cs
@@ -1,0 +1,53 @@
+namespace Mailtrap.ApiTokens.Models;
+
+
+/// <summary>
+/// Represents an explicit API token expiration, serialized as an ISO 8601 date-time.<br/>
+/// Leave the request property unset to omit the value and get the server default
+/// (a 1-year default is being rolled out).<br/>
+/// Use <see cref="Never"/> for a token that never expires.<br/>
+/// Past or more-than-5-years-ahead values are rejected with 422.
+/// </summary>
+[JsonConverter(typeof(ApiTokenExpirationJsonConverter))]
+public sealed record ApiTokenExpiration
+{
+    /// <summary>
+    /// Gets the expiration for a token that never expires.
+    /// </summary>
+    ///
+    /// <value>
+    /// Expiration for a token that never expires. Serialized as JSON <see langword="null"/>.
+    /// </value>
+    public static ApiTokenExpiration Never { get; } = new((DateTimeOffset?)null);
+
+
+    /// <summary>
+    /// Creates an expiration at the provided date and time.
+    /// </summary>
+    ///
+    /// <param name="value">
+    /// Date and time when the token expires.
+    /// </param>
+    ///
+    /// <returns>
+    /// Expiration at the provided date and time. Serialized as an ISO 8601 date-time string.
+    /// </returns>
+    public static ApiTokenExpiration At(DateTimeOffset value) => new(value);
+
+
+    /// <summary>
+    /// Gets the expiration date and time,
+    /// or <see langword="null"/> for a token that never expires.
+    /// </summary>
+    ///
+    /// <value>
+    /// Expiration date and time, or <see langword="null"/> for a token that never expires.
+    /// </value>
+    internal DateTimeOffset? Value { get; }
+
+
+    private ApiTokenExpiration(DateTimeOffset? value)
+    {
+        Value = value;
+    }
+}

--- a/src/Mailtrap.Abstractions/ApiTokens/Requests/CreateApiTokenRequest.cs
+++ b/src/Mailtrap.Abstractions/ApiTokens/Requests/CreateApiTokenRequest.cs
@@ -19,6 +19,20 @@ public sealed record CreateApiTokenRequest : IValidatable
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the optional token expiration.
+    /// </summary>
+    ///
+    /// <value>
+    /// Optional token expiration as an ISO 8601 date-time.<br/>
+    /// Omit for the server default (a 1-year default is being rolled out).<br/>
+    /// Use <see cref="ApiTokenExpiration.Never"/> for a token that never expires.<br/>
+    /// Past or more-than-5-years-ahead values are rejected with 422.
+    /// </value>
+    [JsonPropertyName("expires_at")]
+    [JsonPropertyOrder(2)]
+    public ApiTokenExpiration? ExpiresAt { get; set; }
+
+    /// <summary>
     /// Gets the resource accesses to grant to the API token.
     /// </summary>
     ///
@@ -26,7 +40,7 @@ public sealed record CreateApiTokenRequest : IValidatable
     /// Collection of resource accesses.
     /// </value>
     [JsonPropertyName("resources")]
-    [JsonPropertyOrder(2)]
+    [JsonPropertyOrder(3)]
     [JsonObjectCreationHandling(JsonObjectCreationHandling.Populate)]
     public IList<ApiTokenAccessRequest> Resources { get; } = [];
 

--- a/src/Mailtrap.Abstractions/ApiTokens/Requests/ResetApiTokenRequest.cs
+++ b/src/Mailtrap.Abstractions/ApiTokens/Requests/ResetApiTokenRequest.cs
@@ -1,0 +1,22 @@
+namespace Mailtrap.ApiTokens.Requests;
+
+
+/// <summary>
+/// Request to reset an API token.
+/// </summary>
+public sealed record ResetApiTokenRequest
+{
+    /// <summary>
+    /// Gets or sets the optional expiration for the new token.
+    /// </summary>
+    ///
+    /// <value>
+    /// Optional token expiration as an ISO 8601 date-time.<br/>
+    /// Omit for the server default (a 1-year default is being rolled out).<br/>
+    /// Use <see cref="ApiTokenExpiration.Never"/> for a token that never expires.<br/>
+    /// Past or more-than-5-years-ahead values are rejected with 422.
+    /// </value>
+    [JsonPropertyName("expires_at")]
+    [JsonPropertyOrder(1)]
+    public ApiTokenExpiration? ExpiresAt { get; set; }
+}

--- a/src/Mailtrap.Abstractions/GlobalUsings.cs
+++ b/src/Mailtrap.Abstractions/GlobalUsings.cs
@@ -12,6 +12,7 @@ global using Mailtrap.AccountAccesses.Responses;
 global using Mailtrap.Accounts;
 global using Mailtrap.Accounts.Models;
 global using Mailtrap.ApiTokens;
+global using Mailtrap.ApiTokens.Converters;
 global using Mailtrap.ApiTokens.Models;
 global using Mailtrap.ApiTokens.Requests;
 global using Mailtrap.ApiTokens.Responses;

--- a/src/Mailtrap/ApiTokens/ApiTokenResource.cs
+++ b/src/Mailtrap/ApiTokens/ApiTokenResource.cs
@@ -27,4 +27,18 @@ internal sealed class ApiTokenResource : RestResource, IApiTokenResource
 
         return result;
     }
+
+    public async Task<ApiTokenResetResponse> Reset(ResetApiTokenRequest request, CancellationToken cancellationToken = default)
+    {
+        Ensure.NotNull(request, nameof(request));
+
+        var uri = ResourceUri.Append(ResetSegment);
+
+        var result = await RestResourceCommandFactory
+            .CreatePost<ResetApiTokenRequest, ApiTokenResetResponse>(uri, request)
+            .Execute(cancellationToken)
+            .ConfigureAwait(false);
+
+        return result;
+    }
 }

--- a/tests/Mailtrap.IntegrationTests/ApiTokens/ApiTokensIntegrationTests.cs
+++ b/tests/Mailtrap.IntegrationTests/ApiTokens/ApiTokensIntegrationTests.cs
@@ -92,6 +92,79 @@ internal sealed class ApiTokensIntegrationTests
     }
 
     [Test]
+    public async Task Create_WithExpiration_Success()
+    {
+        // Arrange
+        var request = new CreateApiTokenRequest
+        {
+            Name = "My API Token",
+            ExpiresAt = ApiTokenExpiration.At(DateTimeOffset.Parse("2027-06-01T00:00:00Z", CultureInfo.InvariantCulture))
+        };
+        request.Resources.Add(new ApiTokenAccessRequest(ResourceType.Account, 3229, AccessLevel.Admin));
+
+        const string expectedRequestBody =
+            """{"name":"My API Token","expires_at":"2027-06-01T00:00:00+00:00","resources":[{"resource_type":"account","resource_id":3229,"access_level":100}]}""";
+
+        // Act & Assert
+        await RunCreateSuccessAsync(request, expectedRequestBody);
+    }
+
+    [Test]
+    public async Task Create_WithNeverExpiration_Success()
+    {
+        // Arrange
+        var request = new CreateApiTokenRequest
+        {
+            Name = "My API Token",
+            ExpiresAt = ApiTokenExpiration.Never
+        };
+        request.Resources.Add(new ApiTokenAccessRequest(ResourceType.Account, 3229, AccessLevel.Admin));
+
+        const string expectedRequestBody =
+            """{"name":"My API Token","expires_at":null,"resources":[{"resource_type":"account","resource_id":3229,"access_level":100}]}""";
+
+        // Act & Assert
+        await RunCreateSuccessAsync(request, expectedRequestBody);
+    }
+
+    [Test]
+    public async Task Create_ShouldThrow_WhenExpirationIsRejected()
+    {
+        // Arrange
+        var request = new CreateApiTokenRequest
+        {
+            Name = "My API Token",
+            ExpiresAt = ApiTokenExpiration.At(DateTimeOffset.Parse("2020-01-01T00:00:00Z", CultureInfo.InvariantCulture))
+        };
+        request.Resources.Add(new ApiTokenAccessRequest(ResourceType.Account, 3229, AccessLevel.Admin));
+
+        using var responseContent = await Feature.LoadFileToStringContent();
+
+        using var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .Expect(HttpMethod.Post, _resourceUri.AbsoluteUri)
+            .WithHeaders("Authorization", $"Bearer {_clientConfig.ApiToken}")
+            .WithHeaders("Accept", MimeTypes.Application.Json)
+            .WithHeaders("User-Agent", HeaderValues.UserAgent.ToString())
+            .Respond(HttpStatusCode.UnprocessableEntity, responseContent);
+
+        using var services = BuildServiceProvider(mockHttp);
+        var client = services.GetRequiredService<IMailtrapClient>();
+
+        // Act
+        var act = () => client
+            .Account(_accountId)
+            .ApiTokens()
+            .Create(request);
+
+        // Assert
+        var assertion = await act.Should().ThrowAsync<HttpRequestFailedException>();
+        assertion.Which.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Test]
     public async Task GetDetails_Success()
     {
         // Arrange
@@ -163,15 +236,19 @@ internal sealed class ApiTokensIntegrationTests
         expectedResponse.Should().NotBeNull();
 
         using var mockHttp = new MockHttpMessageHandler();
-        using var clientScope = mockHttp.ConfigureAndCreateClient(
-            HttpMethod.Post,
-            requestUri,
-            responseContent,
-            HttpStatusCode.OK,
-            _clientConfig);
+        mockHttp
+            .Expect(HttpMethod.Post, requestUri)
+            .WithHeaders("Authorization", $"Bearer {_clientConfig.ApiToken}")
+            .WithHeaders("Accept", MimeTypes.Application.Json)
+            .WithHeaders("User-Agent", HeaderValues.UserAgent.ToString())
+            .With(message => message.Content is null)
+            .Respond(HttpStatusCode.OK, responseContent);
+
+        using var services = BuildServiceProvider(mockHttp);
+        var client = services.GetRequiredService<IMailtrapClient>();
 
         // Act
-        var result = await clientScope.Client
+        var result = await client
             .Account(_accountId)
             .ApiToken(apiTokenId)
             .Reset()
@@ -181,5 +258,108 @@ internal sealed class ApiTokensIntegrationTests
         mockHttp.VerifyNoOutstandingExpectation();
 
         result.Should().BeEquivalentTo(expectedResponse);
+    }
+
+    [Test]
+    public async Task Reset_WithExpiration_Success()
+    {
+        // Arrange
+        var request = new ResetApiTokenRequest
+        {
+            ExpiresAt = ApiTokenExpiration.At(DateTimeOffset.Parse("2027-06-01T00:00:00Z", CultureInfo.InvariantCulture))
+        };
+
+        const string expectedRequestBody = """{"expires_at":"2027-06-01T00:00:00+00:00"}""";
+
+        // Act & Assert
+        await RunResetSuccessAsync(request, expectedRequestBody);
+    }
+
+    [Test]
+    public async Task Reset_WithNeverExpiration_Success()
+    {
+        // Arrange
+        var request = new ResetApiTokenRequest
+        {
+            ExpiresAt = ApiTokenExpiration.Never
+        };
+
+        const string expectedRequestBody = """{"expires_at":null}""";
+
+        // Act & Assert
+        await RunResetSuccessAsync(request, expectedRequestBody);
+    }
+
+
+    private async Task RunCreateSuccessAsync(CreateApiTokenRequest request, string expectedRequestBody)
+    {
+        using var responseContent = await Feature.LoadFileToStringContent();
+        var expectedResponse = await responseContent.DeserializeStringContentAsync<CreateApiTokenResponse>(_jsonSerializerOptions);
+        expectedResponse.Should().NotBeNull();
+
+        using var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .Expect(HttpMethod.Post, _resourceUri.AbsoluteUri)
+            .WithHeaders("Authorization", $"Bearer {_clientConfig.ApiToken}")
+            .WithHeaders("Accept", MimeTypes.Application.Json)
+            .WithHeaders("User-Agent", HeaderValues.UserAgent.ToString())
+            .WithContent(expectedRequestBody)
+            .Respond(HttpStatusCode.OK, responseContent);
+
+        using var services = BuildServiceProvider(mockHttp);
+        var client = services.GetRequiredService<IMailtrapClient>();
+
+        var result = await client
+            .Account(_accountId)
+            .ApiTokens()
+            .Create(request)
+            .ConfigureAwait(false);
+
+        mockHttp.VerifyNoOutstandingExpectation();
+
+        result.Should().BeEquivalentTo(expectedResponse);
+    }
+
+    private async Task RunResetSuccessAsync(ResetApiTokenRequest request, string expectedRequestBody)
+    {
+        var apiTokenId = TestContext.CurrentContext.Random.NextLong();
+        var requestUri = _resourceUri.Append(apiTokenId).Append(ResetSegment).AbsoluteUri;
+
+        using var responseContent = await Feature.LoadFileToStringContent();
+        var expectedResponse = await responseContent.DeserializeStringContentAsync<ApiTokenResetResponse>(_jsonSerializerOptions);
+        expectedResponse.Should().NotBeNull();
+
+        using var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .Expect(HttpMethod.Post, requestUri)
+            .WithHeaders("Authorization", $"Bearer {_clientConfig.ApiToken}")
+            .WithHeaders("Accept", MimeTypes.Application.Json)
+            .WithHeaders("User-Agent", HeaderValues.UserAgent.ToString())
+            .WithContent(expectedRequestBody)
+            .Respond(HttpStatusCode.OK, responseContent);
+
+        using var services = BuildServiceProvider(mockHttp);
+        var client = services.GetRequiredService<IMailtrapClient>();
+
+        var result = await client
+            .Account(_accountId)
+            .ApiToken(apiTokenId)
+            .Reset(request)
+            .ConfigureAwait(false);
+
+        mockHttp.VerifyNoOutstandingExpectation();
+
+        result.Should().BeEquivalentTo(expectedResponse);
+    }
+
+    private ServiceProvider BuildServiceProvider(MockHttpMessageHandler mockHttp)
+    {
+        var serviceCollection = new ServiceCollection();
+
+        serviceCollection
+            .AddMailtrapClient(_clientConfig)
+            .ConfigurePrimaryHttpMessageHandler(() => mockHttp);
+
+        return serviceCollection.BuildServiceProvider();
     }
 }

--- a/tests/Mailtrap.IntegrationTests/ApiTokens/Create_ShouldThrow_WhenExpirationIsRejected.json
+++ b/tests/Mailtrap.IntegrationTests/ApiTokens/Create_ShouldThrow_WhenExpirationIsRejected.json
@@ -1,0 +1,7 @@
+{
+  "errors": {
+    "expires_at": [
+      "must be in the future"
+    ]
+  }
+}

--- a/tests/Mailtrap.IntegrationTests/ApiTokens/Create_WithExpiration_Success.json
+++ b/tests/Mailtrap.IntegrationTests/ApiTokens/Create_WithExpiration_Success.json
@@ -1,0 +1,15 @@
+{
+  "id": 12345,
+  "name": "My API Token",
+  "last_4_digits": "x7k9",
+  "created_by": "user@example.com",
+  "expires_at": "2027-06-01T00:00:00Z",
+  "resources": [
+    {
+      "resource_type": "account",
+      "resource_id": 3229,
+      "access_level": 100
+    }
+  ],
+  "token": "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
+}

--- a/tests/Mailtrap.IntegrationTests/ApiTokens/Create_WithNeverExpiration_Success.json
+++ b/tests/Mailtrap.IntegrationTests/ApiTokens/Create_WithNeverExpiration_Success.json
@@ -1,0 +1,15 @@
+{
+  "id": 12345,
+  "name": "My API Token",
+  "last_4_digits": "x7k9",
+  "created_by": "user@example.com",
+  "expires_at": null,
+  "resources": [
+    {
+      "resource_type": "account",
+      "resource_id": 3229,
+      "access_level": 100
+    }
+  ],
+  "token": "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
+}

--- a/tests/Mailtrap.IntegrationTests/ApiTokens/Reset_WithExpiration_Success.json
+++ b/tests/Mailtrap.IntegrationTests/ApiTokens/Reset_WithExpiration_Success.json
@@ -1,0 +1,15 @@
+{
+  "id": 12345,
+  "name": "Production token",
+  "last_4_digits": "z9y8",
+  "created_by": "user@example.com",
+  "expires_at": "2027-06-01T00:00:00Z",
+  "resources": [
+    {
+      "resource_type": "account",
+      "resource_id": 3229,
+      "access_level": 100
+    }
+  ],
+  "token": "newtokenvaluereturnedonresetonceonly1234"
+}

--- a/tests/Mailtrap.IntegrationTests/ApiTokens/Reset_WithNeverExpiration_Success.json
+++ b/tests/Mailtrap.IntegrationTests/ApiTokens/Reset_WithNeverExpiration_Success.json
@@ -1,0 +1,15 @@
+{
+  "id": 12345,
+  "name": "Production token",
+  "last_4_digits": "z9y8",
+  "created_by": "user@example.com",
+  "expires_at": null,
+  "resources": [
+    {
+      "resource_type": "account",
+      "resource_id": 3229,
+      "access_level": 100
+    }
+  ],
+  "token": "newtokenvaluereturnedonresetonceonly1234"
+}

--- a/tests/Mailtrap.UnitTests/ApiTokens/ApiTokenExpirationTests.cs
+++ b/tests/Mailtrap.UnitTests/ApiTokens/ApiTokenExpirationTests.cs
@@ -1,0 +1,140 @@
+using System.Globalization;
+
+namespace Mailtrap.UnitTests.ApiTokens;
+
+
+[TestFixture]
+internal sealed class ApiTokenExpirationTests
+{
+    private const string ExpirationDateRaw = "2027-06-01T00:00:00Z";
+    private const string ExpirationDateSerialized = "2027-06-01T00:00:00+00:00";
+
+    private static readonly DateTimeOffset s_expirationDate =
+        DateTimeOffset.Parse(ExpirationDateRaw, CultureInfo.InvariantCulture);
+
+
+    #region CreateApiTokenRequest serialization
+
+    [Test]
+    public void CreateRequest_ShouldOmitExpiresAtKey_WhenExpirationIsNotSet()
+    {
+        var request = new CreateApiTokenRequest { Name = "My API Token" };
+
+        var serialized = JsonSerializer.Serialize(request, MailtrapJsonSerializerOptions.NotIndented);
+
+        serialized.Should().Be("""{"name":"My API Token","resources":[]}""");
+    }
+
+    [Test]
+    public void CreateRequest_ShouldWriteNullExpiresAt_WhenExpirationIsNever()
+    {
+        var request = new CreateApiTokenRequest
+        {
+            Name = "My API Token",
+            ExpiresAt = ApiTokenExpiration.Never
+        };
+
+        var serialized = JsonSerializer.Serialize(request, MailtrapJsonSerializerOptions.NotIndented);
+
+        serialized.Should().Be("""{"name":"My API Token","expires_at":null,"resources":[]}""");
+    }
+
+    [Test]
+    public void CreateRequest_ShouldWriteIsoStringExpiresAt_WhenExpirationIsSet()
+    {
+        var request = new CreateApiTokenRequest
+        {
+            Name = "My API Token",
+            ExpiresAt = ApiTokenExpiration.At(s_expirationDate)
+        };
+
+        var serialized = JsonSerializer.Serialize(request, MailtrapJsonSerializerOptions.NotIndented);
+
+        serialized.Should().Be($$"""{"name":"My API Token","expires_at":"{{ExpirationDateSerialized}}","resources":[]}""");
+    }
+
+    #endregion
+
+
+    #region ResetApiTokenRequest serialization
+
+    [Test]
+    public void ResetRequest_ShouldOmitExpiresAtKey_WhenExpirationIsNotSet()
+    {
+        var request = new ResetApiTokenRequest();
+
+        var serialized = JsonSerializer.Serialize(request, MailtrapJsonSerializerOptions.NotIndented);
+
+        serialized.Should().Be("{}");
+    }
+
+    [Test]
+    public void ResetRequest_ShouldWriteNullExpiresAt_WhenExpirationIsNever()
+    {
+        var request = new ResetApiTokenRequest { ExpiresAt = ApiTokenExpiration.Never };
+
+        var serialized = JsonSerializer.Serialize(request, MailtrapJsonSerializerOptions.NotIndented);
+
+        serialized.Should().Be("""{"expires_at":null}""");
+    }
+
+    [Test]
+    public void ResetRequest_ShouldWriteIsoStringExpiresAt_WhenExpirationIsSet()
+    {
+        var request = new ResetApiTokenRequest { ExpiresAt = ApiTokenExpiration.At(s_expirationDate) };
+
+        var serialized = JsonSerializer.Serialize(request, MailtrapJsonSerializerOptions.NotIndented);
+
+        serialized.Should().Be($$"""{"expires_at":"{{ExpirationDateSerialized}}"}""");
+    }
+
+    #endregion
+
+
+    #region Deserialization
+
+    [Test]
+    public void CreateRequest_ShouldDeserializeMissingExpiresAt_ToNull()
+    {
+        var deserialized = JsonSerializer.Deserialize<CreateApiTokenRequest>(
+            """{"name":"My API Token","resources":[]}""",
+            MailtrapJsonSerializerOptions.NotIndented);
+
+        deserialized.Should().NotBeNull();
+        deserialized!.ExpiresAt.Should().BeNull();
+    }
+
+    [Test]
+    public void CreateRequest_ShouldDeserializeNullExpiresAt_ToNever()
+    {
+        var deserialized = JsonSerializer.Deserialize<CreateApiTokenRequest>(
+            """{"name":"My API Token","expires_at":null,"resources":[]}""",
+            MailtrapJsonSerializerOptions.NotIndented);
+
+        deserialized.Should().NotBeNull();
+        deserialized!.ExpiresAt.Should().Be(ApiTokenExpiration.Never);
+    }
+
+    [Test]
+    public void ResetRequest_ShouldDeserializeStringExpiresAt_ToExpirationAtDate()
+    {
+        var deserialized = JsonSerializer.Deserialize<ResetApiTokenRequest>(
+            $$"""{"expires_at":"{{ExpirationDateRaw}}"}""",
+            MailtrapJsonSerializerOptions.NotIndented);
+
+        deserialized.Should().NotBeNull();
+        deserialized!.ExpiresAt.Should().Be(ApiTokenExpiration.At(s_expirationDate));
+    }
+
+    [Test]
+    public void ResetRequest_ShouldThrowJsonException_WhenExpiresAtIsNotParseable()
+    {
+        var act = () => JsonSerializer.Deserialize<ResetApiTokenRequest>(
+            """{"expires_at":"not-a-date"}""",
+            MailtrapJsonSerializerOptions.NotIndented);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    #endregion
+}

--- a/tests/Mailtrap.UnitTests/ApiTokens/ApiTokenResourceTests.cs
+++ b/tests/Mailtrap.UnitTests/ApiTokens/ApiTokenResourceTests.cs
@@ -49,6 +49,24 @@ internal sealed class ApiTokenResourceTests
     #endregion
 
 
+    #region Reset
+
+    [Test]
+    public async Task Reset_ShouldThrowArgumentNullException_WhenRequestIsNull()
+    {
+        // Arrange
+        var resource = CreateResource();
+
+        // Act
+        var act = () => resource.Reset(null!);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    #endregion
+
+
 
     private ApiTokenResource CreateResource() => new(_commandFactoryMock, _resourceUri);
 }

--- a/tests/Mailtrap.UnitTests/GlobalUsings.cs
+++ b/tests/Mailtrap.UnitTests/GlobalUsings.cs
@@ -12,6 +12,7 @@ global using Mailtrap.AccountAccesses.Models;
 global using Mailtrap.AccountAccesses.Requests;
 global using Mailtrap.Accounts;
 global using Mailtrap.ApiTokens;
+global using Mailtrap.ApiTokens.Models;
 global using Mailtrap.ApiTokens.Requests;
 global using Mailtrap.ApiTokens.Validators;
 global using Mailtrap.Attachments;


### PR DESCRIPTION
## Motivation

[MT-23076](https://railsware.atlassian.net/browse/MT-23076) – the Mailtrap API token endpoints now accept an optional `expires_at` value. This exposes it in the .NET SDK.

## Changes

- new `ApiTokenExpiration` type with a custom JSON converter implementing the tri-state contract: property unset – `expires_at` key omitted from the body (server default, a 1-year default is being rolled out behind a feature flag); `ApiTokenExpiration.Never` – explicit `"expires_at": null` (token never expires); `ApiTokenExpiration.At(...)` – ISO 8601 date-time string
- `CreateApiTokenRequest.ExpiresAt` for the `createApiToken` operation (optional nullable `expires_at` in the request body)
- new `ResetApiTokenRequest` and an `IApiTokenResource.Reset(ResetApiTokenRequest, CancellationToken)` overload for the `resetApiToken` operation, whose request body is now optional; the existing parameterless `Reset()` keeps sending no body
- no client-side date validation – past, unparseable, or more-than-5-years-ahead values are rejected by the API with 422
- `Specifier.MaskedToken` – the account-access `ApiToken` specifier has `masked_token` in the spec, which the SDK model was missing
- unit and integration tests covering the three serialization cases, the unchanged no-body reset, and the 422 error path
- api tokens example extended with expiration usage

Note: adding a member to `IApiTokenResource` is source-breaking for external implementors of that interface.

## How to test

- [ ] call `client.Account(id).ApiTokens().Create(request)` without setting `ExpiresAt` – the request body contains no `expires_at` key; with the server flag enabled the created token gets the default 1-year `expires_at` in the response
- [ ] create with `ExpiresAt = ApiTokenExpiration.Never` – the request body contains `"expires_at": null` and the response has `expires_at: null`
- [ ] create with `ExpiresAt = ApiTokenExpiration.At(DateTimeOffset.Parse("2027-06-01T00:00:00Z"))` – the request body contains the ISO date-time and the response echoes it
- [ ] create with a past date – the call throws `HttpRequestFailedException` with status 422
- [ ] call `apiToken.Reset()` (parameterless) – the request is sent without a body and succeeds exactly as before this change
- [ ] call `apiToken.Reset(new ResetApiTokenRequest { ExpiresAt = ApiTokenExpiration.Never })` – the request body is `{"expires_at":null}` and the new token never expires
- [ ] list tokens and get token details – `expires_at` is returned in responses as before

## Companion PRs

- other MT-23076 SDK PRs: mailtrap/mailtrap-nodejs#149, mailtrap/mailtrap-mcp#136, mailtrap/mailtrap-php#75, mailtrap/mailtrap-python#77, mailtrap/mailtrap-ruby#122, mailtrap/mailtrap-java#68, mailtrap/mailtrap-go#28, mailtrap/mailtrap-cli#12
- falcon PR railsware/falcon#10763
- spec PR mailtrap/mailtrap-openapi#51

Caveat: release/merge only after falcon deploys MT-23076 and zap_api_token_expiration is enabled in production.

[MT-23076]: https://railsware.atlassian.net/browse/MT-23076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ